### PR TITLE
chore: add commitlint and husky commit-msg hook

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx --no -- commitlint --edit "$1"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ Example:
     docker run -ti -v $(pwd):/var/work thinxcloud/console-build-env:vue cd /var/work && npm run test:unit
 
 
+## Commit Convention
+
+Commits must follow [Conventional Commits](https://www.conventionalcommits.org/) format:
+
+```
+type(scope): description
+```
+
+Common types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`.
+
+The `commit-msg` git hook enforces this via [commitlint](https://commitlint.js.org/). Install it by running `yarn install` inside the `vue/` directory (the `prepare` script wires husky automatically).
+
 ## License
 
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fsuculent%2Fthinx-console.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fsuculent%2Fthinx-console?ref=badge_large)

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = { extends: ['@commitlint/config-conventional'] };

--- a/vue/package.json
+++ b/vue/package.json
@@ -10,7 +10,8 @@
     "cy:test": "cypress run",
     "cy:open": "cypress open",
     "test": "start-server-and-test serve http://127.0.0.1:3000/ cy:test",
-    "eslint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore"
+    "eslint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore",
+    "prepare": "cd .. && npx husky install"
   },
   "dependencies": {
     "@amcharts/amcharts4": "^4.10.13",
@@ -55,7 +56,10 @@
     "webpack-cli": "4.47.0"
   },
   "devDependencies": {
+    "@commitlint/cli": "^19.0.0",
+    "@commitlint/config-conventional": "^19.0.0",
     "@cypress/vite-dev-server": "^2.2.2",
+    "husky": "^9.0.0",
     "@rushstack/eslint-patch": "^1.1.0",
     "@types/node": "^16.11.25",
     "@vue/cli-plugin-babel": "^5.0.0",


### PR DESCRIPTION
## Summary

- Adds `commitlint.config.js` at the git root enforcing `@commitlint/config-conventional` rules
- Adds `.husky/commit-msg` executable hook that runs commitlint on every commit
- Updates `vue/package.json`: adds `@commitlint/cli`, `@commitlint/config-conventional`, `husky` to devDependencies and a `prepare` script (`cd .. && npx husky install`) so the hook installs relative to the git root
- Documents the commit convention in `README.md`

## Test plan

- [ ] Run `yarn install` in `vue/` — the `prepare` script should call `husky install` and print no errors
- [ ] Attempt a commit with a non-conventional message (e.g. `git commit --allow-empty -m "bad message"`) — commitlint should reject it
- [ ] Attempt a commit with a valid message (e.g. `fix(api): correct timeout`) — it should pass

Nightshift-Task: commit-normalize
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: commit-normalize:/Users/igraczech/Repositories/thinx-device-api/services/console
task-type: commit-normalize
task-title: Commit Message Normalizer
iterations: 1
duration: 4m13s
nightshift:metadata -->
