### PR TITLE
docs: draft release notes for thinx-staging (2026-05-19)

### DIFF
--- a/.planning/phase-3/CONTEXT.md
+++ b/.planning/phase-3/CONTEXT.md
@@ -1,0 +1,105 @@
+# Phase 3: Transformers with Code Editor - Context
+
+**Gathered:** 2026-05-19
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Transformers are fully manageable with a proper code editing experience. This phase delivers:
+- Transformer list with create (alias only) + delete
+- TransformerEditor page at `/app/transformer/:utid` with CodeMirror 5 JS editor
+- Base64 encode on save, decode on load (with UTF-8 safety wrapper)
+- Unsaved-changes guard via `beforeRouteLeave`
+- Duplicate alias prevention in create modal
+
+**Both Transformers.vue and TransformerEditor.vue are already scaffolded** — this phase is verification, targeted fixes, and closing 4 specific gaps identified in discussion.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### TRAN-01: Store decoupling from /profile
+- **D-01:** Accept the current POST /api/v2/profile approach — no dedicated `/transformer` CRUD endpoints exist on the backend (confirmed via codebase scan). The store already sends only `{ transformers: [...] }`, not the full profile; `owner.js process_update` handles partial updates safely.
+- **D-02:** The planner should verify the store's `fetchItems` path is self-contained (reads from `result.response.info.transformers` after GET /api/v2/profile) and add a code comment explaining the backend constraint so future developers understand why `/transformer` endpoints are not used.
+
+### Duplicate alias guard
+- **D-03:** Add duplicate alias detection to `create()` in `Transformers.vue` using `this.items.find(t => t.alias === alias)`. Show an inline `<b-alert>` error inside the create modal (same pattern as REPO-03 in Repositories.vue). Clear the error at the start of each `create()` call.
+
+### Post-save navigation
+- **D-04:** After a successful save in `TransformerEditor.vue`, navigate back to `/app/transformers` (replace the current "stay on page + green banner" behavior). Clear `hasChanges = false` before navigating to avoid triggering the `beforeRouteLeave` guard.
+
+### btoa/atob UTF-8 safety
+- **D-05:** Replace the raw `btoa(body)` call in the store's `updateItem` action with a UTF-8 safe encode wrapper: `btoa(unescape(encodeURIComponent(body)))`. Replace the `atob(transformer.body)` decode in `TransformerEditor.vue` with: `decodeURIComponent(escape(atob(transformer.body)))`. The existing try/catch around the decode call should remain as a fallback for malformed stored data.
+
+### Claude's Discretion
+- CodeMirror editor height (currently 400px fixed) — maintain as-is unless there's a functional reason to change
+- Editor tab size, theme, line numbers — already configured in `editorOptions`; maintain current values
+- Success feedback on save — a brief toast or redirect banner is acceptable, but the redirect to list is the primary UX
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Core implementation files
+- `vue/src/store/transformers.js` — current store: fetchItems, createItem, updateItem, deleteItem, saveTransformers
+- `vue/src/pages/Transformers/Transformers.vue` — list page with create modal and delete confirm
+- `vue/src/pages/Transformers/TransformerEditor.vue` — editor page with CodeMirror, beforeRouteLeave, save/cancel
+- `vue/src/Routes.js` — transformer routes already registered here
+
+### API constraint reference
+- `services/console/IMPLEMENTATION_PLAN.md` — API endpoint map; the `/transformer` POST/DELETE rows are marked "missing" and should be treated as "will not be implemented" (backend does not support them)
+- `.planning/phase-3/RESEARCH.md` — full research with verified API findings, pitfalls, and code patterns
+
+### Phase 2 pattern reference (for alias guard)
+- `vue/src/pages/Repositories/Repositories.vue` — REPO-03 duplicate alias guard implementation to mirror in Transformers.vue
+
+### Project requirements
+- `.planning/REQUIREMENTS.md` — TRAN-01 through TRAN-07 definitions
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- `codemirror@5.65.21` + `vue-codemirror@4.0.6`: already installed, do NOT upgrade (Vue 3 incompatible)
+- `this.$bvModal.msgBoxConfirm`: used for delete confirm and beforeRouteLeave — same for any new confirm dialogs
+- `<b-alert>` with `:show="!!error"` pattern from Repositories.vue: reuse for alias guard error display
+
+### Established Patterns
+- Store modules use `mapGetters` spread into `methods` (not `computed`) — existing convention, do not refactor
+- `this.$api.$post('/profile', JSON.stringify({ transformers }))` — the correct profile write pattern; note `JSON.stringify` wrapping
+- `this.$api.$get('/profile')` resolves to `GET /api/v2/profile` (ThinxApi prepends `/api/v2` to all paths)
+
+### Integration Points
+- `Transformers.vue` create modal → `transformers/createItem` action → POST /api/v2/profile
+- `TransformerEditor.vue` save → `transformers/updateItem` action → btoa encode → POST /api/v2/profile
+- Both routes already registered: `{ path: '/app/transformers', name: 'Transformers' }` and `{ path: '/app/transformer/:utid', name: 'TransformerEditor' }`
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- Post-save navigation: `this.$router.push('/app/transformers')` after `this.hasChanges = false` in the `save()` method's success branch
+- Alias guard mirrors Repositories.vue exactly — same `b-alert` placement inside the modal, same `this.error = null` at start of `create()`
+- UTF-8 safe wrappers: encode = `btoa(unescape(encodeURIComponent(body)))`, decode = `decodeURIComponent(escape(atob(s)))` — standard browser-safe pattern, no libraries needed
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+None — discussion stayed within phase scope.
+
+</deferred>
+
+---
+
+*Phase: 3-Transformers with Code Editor*
+*Context gathered: 2026-05-19*

--- a/.planning/phase-3/DISCUSSION-LOG.md
+++ b/.planning/phase-3/DISCUSSION-LOG.md
@@ -1,0 +1,72 @@
+# Phase 3: Transformers with Code Editor - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2026-05-19
+**Phase:** 3-Transformers with Code Editor
+**Areas discussed:** TRAN-01 scope, Duplicate alias guard, Post-save navigation, btoa safety
+
+---
+
+## TRAN-01 Scope
+
+First clarified that the user expected editing without submitting the whole profile. Explained the backend constraint: no dedicated `/transformer` CRUD endpoints exist; `POST /api/v2/profile` with `{ transformers: [...] }` is the only write path, and it updates only the `transformers` field (not the full profile blob).
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Verify and document only | Store is already isolated; planner adds a comment explaining the constraint | |
+| Rename/restructure fetchItems | Refactor to make the profile dependency less surprising | |
+| User's initial response | "Seems to allow editing transformers without submitting whole /profile" | (clarification needed) |
+| Accept current behavior | Current POST /profile approach is correct; verify isolation + add comment | ✓ |
+| Raise backend gap | Document TRAN-01 as partial gap like REPO-05 | |
+
+**User's choice:** Accept current behavior (after constraint clarification)
+**Notes:** User initially expected a dedicated transformer endpoint but accepted the profile-based approach once the backend constraint was confirmed.
+
+---
+
+## Duplicate Alias Guard
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Yes — add it | Mirror REPO-03 pattern from Repositories.vue | ✓ |
+| No — skip it | Allow duplicate aliases, let backend handle | |
+
+**User's choice:** Yes — add it
+**Notes:** No additional notes.
+
+---
+
+## Post-save Navigation
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Stay on editor page | Show green banner, keep editor open (current behavior) | |
+| Navigate back to list | Redirect to /app/transformers on successful save | ✓ |
+
+**User's choice:** Navigate back to transformer list
+**Notes:** Clear `hasChanges = false` before navigating to avoid triggering the `beforeRouteLeave` guard.
+
+---
+
+## btoa Safety
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Add UTF-8 safe wrapper | btoa(unescape(encodeURIComponent(body))) encode; decodeURIComponent(escape(atob(s))) decode | ✓ |
+| Keep as-is, show error on failure | Leave btoa/atob raw; catch and show error banner | |
+
+**User's choice:** Add UTF-8 safe wrapper
+**Notes:** Standard browser-safe pattern; no new dependencies. Existing try/catch on decode remains as a fallback.
+
+---
+
+## Claude's Discretion
+
+- CodeMirror editor height (400px), theme (material), tab size (2), line numbers — maintain current values
+- Success feedback UX on save — redirect to list is the primary signal; brief toast optional
+
+## Deferred Ideas
+
+None — discussion stayed within phase scope.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,84 @@
+# Release Notes — thinx-staging (2026-05-19)
+
+Changes since baseline commit `4d88280` (TASK_GROOMING.md). Intended audience: operators and developers reviewing the staging release.
+
+---
+
+## Features
+
+### Duplicate alias guard in Repositories create modal
+
+**Commit:** `5d18b27` · `feat(REPO-03)`
+
+Attempting to create a repository with an alias that already exists in the list now shows an inline error inside the create modal instead of silently overwriting or failing at the API level. The guard runs client-side before any network request is made.
+
+**Files:** `vue/src/pages/Repositories/Repositories.vue`
+
+---
+
+### Copy-to-clipboard button in one-time key reveal modals
+
+**Commits:** `8611ec1` · `feat(AKEY-02, RKEY-02)`
+
+API key and RSA key modals that reveal one-time secrets now include a **Copy** button alongside the displayed value. This removes the need for users to manually select and copy text from the modal before dismissing it — the secret cannot be retrieved again after the modal is closed.
+
+**Files:** `vue/src/pages/Apikeys/Apikeys.vue`, `vue/src/pages/Rsakeys/Rsakeys.vue`
+
+---
+
+## Bug Fixes
+
+### Transformer ID generation uses `crypto.randomUUID()`
+
+**Commit:** `716166f` · `fix(TRAN)`
+
+Transformer records were previously assigned IDs using `String(Date.now())`. Under rapid creation this produced duplicate IDs and caused silent overwrites. The store now calls `crypto.randomUUID()`, falling back to `Date.now()` only in environments where the Web Crypto API is unavailable.
+
+**Files:** `vue/src/store/transformers.js`
+
+---
+
+### Device list restores when search is cleared
+
+**Commit:** `6587bf1`
+
+Clearing the search box on the device list page left the list empty instead of showing all devices. The filter function returned nothing when `searchText` was an empty string because the per-property guard used `continue` unconditionally, preventing any device from matching. An early return for the no-filter case restores the full list.
+
+**Files:** `src/app/js/main.js`
+
+---
+
+### Auth redirect guard in Vue console
+
+**Commit:** `e0b106e`
+
+The Vue router and login page could loop or redirect to an invalid route when a user was already authenticated. Guards now check session state before issuing a redirect, preventing spurious navigation on page load.
+
+**Files:** `vue/src/App.vue`, `vue/src/pages/Login/Login.vue`
+
+---
+
+### Login form autocomplete attributes corrected
+
+**Commit:** `7dfb483`
+
+The login form lacked explicit `autocomplete` attributes, causing browsers to misidentify the fields or suppress credential autofill. Correct `autocomplete="username"` and `autocomplete="current-password"` values are now set.
+
+**Files:** `vue/src/pages/Login/Login.vue`
+
+---
+
+## Known Gaps
+
+### Repositories page cannot display device counts (REPO-05)
+
+The Repositories page design calls for a device count column showing how many devices are linked to each repository. The `GET /source` backend endpoint does not return a device count field in its response payload. The column has been omitted from the UI rather than showing placeholder zeros.
+
+**Status:** Backend API change required — out of scope for this release.
+
+---
+
+## Housekeeping
+
+- `a09187e` — JSDoc added for Vue core components, store modules, and mixins (no runtime change).
+- `7165797` — `commitlint` and `husky` commit-msg hook added to enforce conventional commit format.

--- a/vue/src/store/transformers.js
+++ b/vue/src/store/transformers.js
@@ -37,7 +37,7 @@ export default {
       },
       async createItem({ state, dispatch }, alias) {
         await dispatch('fetchItems');
-        const utid = String(Date.now());
+        const utid = (typeof crypto !== 'undefined' && crypto.randomUUID) ? crypto.randomUUID() : String(Date.now());
         const defaultBody = btoa('// Minimal no-op Transformer\n\nvar transformer = function(status, device) {\n    return status;\n};');
         const transformers = [...state.items.map(t => ({ utid: t.utid, alias: t.alias, body: t.body })), { utid, alias, body: defaultBody }];
         return dispatch('saveTransformers', transformers);


### PR DESCRIPTION
## Summary

- Drafts `RELEASE_NOTES.md` covering all user-facing changes on `thinx-staging` since the `4d88280` baseline commit
- Documents 2 features (duplicate alias guard in Repositories, copy-to-clipboard in API/RSA key modals), 1 fix (transformer ID collision via `crypto.randomUUID()`), and 3 minor UX fixes from phase 1
- Calls out the REPO-05 known gap (device count missing from `GET /source` response)

## Deliverables

| Area | Commit | Change |
|------|--------|--------|
| feat | `5d18b27` REPO-03 | Duplicate alias guard in Repositories create modal |
| feat | `8611ec1` AKEY-02/RKEY-02 | Copy-to-clipboard in one-time key reveal modals |
| fix  | `716166f` TRAN | `crypto.randomUUID()` for transformer ID generation |
| fix  | `6587bf1` | Device list restored on empty search |
| fix  | `e0b106e` | Auth redirect guard |
| fix  | `7dfb483` | Login autocomplete attributes |
| gap  | REPO-05 | Device count column omitted — backend API gap |

## Test plan

- [ ] Read `RELEASE_NOTES.md` and verify all section descriptions match the referenced commits
- [ ] Confirm no user-facing commits between `4d88280` and `HEAD` on `thinx-staging` are missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: release-notes:/Users/igraczech/Repositories/thinx-device-api/services/console
task-type: release-notes
task-title: Release Note Drafter
iterations: 1
duration: 2m50s
nightshift:metadata -->
