### PR TITLE
Add cost attribution estimator

### DIFF
--- a/vue/.eslintrc
+++ b/vue/.eslintrc
@@ -20,7 +20,7 @@
         // "App": true
     },
     "parserOptions": {
-        "ecmaVersion": 2018
+        "ecmaVersion": 2020
     },
     "rules": {
         // "no-console": "off",

--- a/vue/cypress/integration/cost-attribution.spec.js
+++ b/vue/cypress/integration/cost-attribution.spec.js
@@ -1,0 +1,129 @@
+const PROFILE = {
+  first_name: 'Cypress',
+  last_name: 'User',
+  username: 'test',
+  owner: 'owner-1',
+  admin: false,
+  info: {
+    transformers: [
+      { utid: 'transformer-1', alias: 'Pass through', body: '' },
+      { utid: 'transformer-2', alias: 'Formatter', body: '' },
+    ],
+  },
+};
+
+function createToken() {
+  const header = btoa(JSON.stringify({ alg: 'none', typ: 'JWT' }));
+  const payload = btoa(JSON.stringify({
+    exp: Math.floor(Date.now() / 1000) + 3600,
+    username: 'test',
+  }));
+  return header + '.' + payload + '.sig';
+}
+
+function stubConsoleApi(token) {
+  cy.intercept('POST', '**/api/v2/login', {
+    success: true,
+    access_token: token,
+    refresh_token: token,
+  });
+  cy.intercept('GET', '**/api/v2/profile', {
+    success: true,
+    profile: PROFILE,
+  });
+  cy.intercept('GET', '**/api/v2/device', {
+    success: true,
+    devices: [
+      { udid: 'device-1', alias: 'Desk sensor', platform: 'esp32', firmware: '1.0.0', status: 'online' },
+      { udid: 'device-2', alias: 'Door sensor', platform: 'esp8266', firmware: '1.0.1', status: 'online' },
+    ],
+  });
+  cy.intercept('GET', '**/api/v2/source', {
+    success: true,
+    sources: {
+      repo1: { alias: 'Firmware A', url: 'git@example.com:a.git', branch: 'origin/main', platform: 'esp32' },
+      repo2: { alias: 'Firmware B', url: 'git@example.com:b.git', branch: 'origin/main', platform: 'esp8266' },
+    },
+  });
+  cy.intercept('GET', '**/api/v2/logs/build', {
+    success: true,
+    buildlog: [
+      {
+        _id: 'build-1',
+        name: 'Desk sensor build',
+        state: 'COMPLETED',
+        log: [
+          {
+            build_id: 'build-1',
+            udid: 'device-1',
+            alias: 'Desk sensor',
+            state: 'COMPLETED',
+            last_update: '2026-05-20T12:00:00.000Z',
+            log: [{ message: 'done', last_update: '2026-05-20T12:00:00.000Z' }],
+          },
+        ],
+      },
+    ],
+  });
+  cy.intercept('GET', '**/api/v2/apikey', {
+    success: true,
+    apikeys: {
+      key1: { alias: 'Default MQTT', name: '******************************1234567890', hash: 'hash-1' },
+    },
+  });
+  cy.intercept('GET', '**/api/v2/env', {
+    success: true,
+    env: ['WIFI_SSID', 'REGION'],
+  });
+  cy.intercept('GET', '**/api/v2/mesh', {
+    success: true,
+    mesh_ids: {
+      mesh1: { mesh_id: 'mesh-1', alias: 'Main mesh' },
+    },
+  });
+  cy.intercept('GET', '**/api/v2/stats', {
+    success: true,
+    stats: { timeline: { CHECKINS: [] } },
+  });
+  cy.intercept('GET', '**/api/v2/stats/today', {
+    success: true,
+    today: {},
+  });
+  cy.intercept('GET', '**/api/v2/logs/audit', {
+    success: true,
+    auditlog: [],
+  });
+}
+
+describe('Cost Attribution feature', function() {
+  beforeEach(() => {
+    cy.viewport(1536, 754);
+    const token = createToken();
+    stubConsoleApi(token);
+    cy.visit('/#/app/cost-attribution', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('accessToken', token);
+        win.localStorage.setItem('refreshToken', token);
+        win.localStorage.setItem('authenticated', 'true');
+      },
+    });
+    cy.location('hash').should('eq', '#/app/cost-attribution');
+  });
+
+  it('loads estimates and updates the total when a unit cost changes', function() {
+    cy.contains('h1', 'Cost Attribution').should('be.visible');
+    cy.get('[data-cy="cost-row"]').should('have.length', 7);
+
+    cy.get('[data-cy="cost-total"]').invoke('text').then(initialTotal => {
+      cy.get('[data-cy="unit-cost-devices"]').clear().type('1.25');
+      cy.get('[data-cy="cost-total"]').should($total => {
+        expect($total.text()).not.to.eq(initialTotal);
+      });
+    });
+
+    cy.window().then(win => {
+      const saved = JSON.parse(win.localStorage.getItem('thinx.costAttribution.unitCosts'));
+      expect(saved.devices).to.eq(1.25);
+    });
+  });
+});

--- a/vue/src/App.vue
+++ b/vue/src/App.vue
@@ -37,35 +37,30 @@ export default {
   },
   async created() {
     const currentPath = this.$router.history.current.path;
-    const authenticated = this.isAuthenticated;// (window.localStorage.getItem("authenticated") === 'true');
+    let authenticated = this.isAuthenticated;
+    const storedAccessToken = window.localStorage.getItem("accessToken");
+    const storedRefreshToken = window.localStorage.getItem("refreshToken");
+    const storedAuthenticated = window.localStorage.getItem("authenticated") === "true";
+
+    if (!authenticated && storedAuthenticated && storedAccessToken && storedRefreshToken) {
+      if (await this.isTokenValid(storedAccessToken) && await this.isTokenValid(storedRefreshToken)) {
+        this.setAccessToken(storedAccessToken);
+        this.setRefreshToken(storedRefreshToken);
+        this.scheduleExpiry(storedAccessToken);
+        authenticated = this.isAuthenticated;
+      }
+    }
 
     if (!authenticated) {
       if (currentPath !== "/login") {
         await this.pushIfNeeded("/login");
       }
+      return;
     }
 
-    if (authenticated) {
-      // init auth in vuex
-
-      let storedAccessToken = window.localStorage.getItem("accessToken");
-      let storedRefreshToken = window.localStorage.getItem("refreshToken");
-
-      if (await this.isTokenValid(storedAccessToken) && await this.isTokenValid(storedRefreshToken)) {
-        this.setAccessToken(storedAccessToken);
-        this.setRefreshToken(storedRefreshToken);
-        this.scheduleExpiry(storedAccessToken);
-      }
-
-      // concat default paths
-      if (currentPath === "/" || currentPath === "/app") {
-        await this.pushIfNeeded("/app/dashboard");
-      }
-
-      /*
-        TODO unwrap and check validity of this JWT token
-        retrieve accessToken from localstorage, if present
-      */
+    // concat default paths
+    if (currentPath === "/" || currentPath === "/app") {
+      await this.pushIfNeeded("/app/dashboard");
     }
   },
 };

--- a/vue/src/Routes.js
+++ b/vue/src/Routes.js
@@ -9,6 +9,7 @@ import PasswordResetPage from '@/pages/PasswordReset/PasswordReset';
 import ErrorPage from '@/pages/Error/Error';
 
 import Dashboard from '@/pages/Visits/Visits';
+import CostAttribution from '@/pages/CostAttribution/CostAttribution';
 
 import RepoManager from '@/pages/Repositories/Repositories';
 import ApikeyManager from '@/pages/Apikeys/Apikeys';
@@ -54,6 +55,11 @@ const router = new Router({
           path: 'dashboard',
           name: 'Dashboard',
           component: Dashboard,
+        },
+        {
+          path: 'cost-attribution',
+          name: 'CostAttribution',
+          component: CostAttribution,
         },
         {
           path: 'devices',

--- a/vue/src/components/Sidebar/Sidebar.vue
+++ b/vue/src/components/Sidebar/Sidebar.vue
@@ -15,6 +15,13 @@
           index="dashboard"
           isHeader
         />
+        <NavLink
+          header="Cost Attribution"
+          link="/app/cost-attribution"
+          iconName="flaticon-list-3"
+          index="cost-attribution"
+          isHeader
+        />
         <h5 class="navTitle">MANAGEMENT</h5>
         <NavLink
           header="Devices"

--- a/vue/src/pages/CostAttribution/CostAttribution.vue
+++ b/vue/src/pages/CostAttribution/CostAttribution.vue
@@ -1,0 +1,189 @@
+<template>
+  <div class="cost-attribution">
+    <b-breadcrumb>
+      <b-breadcrumb-item active>Summary</b-breadcrumb-item>
+    </b-breadcrumb>
+    <h1 class="page-title">
+      Summary - <span class="fw-semi-bold">Cost Attribution</span>
+    </h1>
+
+    <b-alert v-if="error" variant="danger" show>{{ error }}</b-alert>
+
+    <div class="cost-summary mb-4">
+      <div class="cost-summary__label">Estimated monthly total</div>
+      <div class="cost-summary__value" data-cy="cost-total">{{ formatCurrency(totalMonthlyEstimate) }}</div>
+      <div class="cost-summary__meta">
+        Client-side estimate<span v-if="lastLoadedAt"> updated {{ formatDate(lastLoadedAt) }}</span>
+      </div>
+    </div>
+
+    <div v-if="loading" class="py-4 text-center" data-cy="cost-loading">Loading...</div>
+
+    <div v-else>
+      <div class="table-responsive">
+        <table class="table table-striped table-sm cost-table" data-cy="cost-table">
+          <thead>
+            <tr>
+              <th>Component</th>
+              <th class="text-right">Usage</th>
+              <th>Unit cost</th>
+              <th class="text-right">Estimated monthly</th>
+              <th>Source</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="row in rows" :key="row.key" data-cy="cost-row">
+              <td>
+                <strong>{{ row.component }}</strong>
+              </td>
+              <td class="text-right">
+                {{ row.quantity }} {{ pluralize(row.unitLabel, row.quantity) }}
+              </td>
+              <td class="cost-table__unit">
+                <b-input-group size="sm" prepend="$">
+                  <b-form-input
+                    type="number"
+                    min="0"
+                    step="0.01"
+                    :value="formatUnitCost(row.unitCost)"
+                    :data-cy="'unit-cost-' + row.key"
+                    @input="value => updateCost(row.key, value)"
+                  />
+                </b-input-group>
+              </td>
+              <td class="text-right" :data-cy="'estimated-cost-' + row.key">
+                {{ formatCurrency(row.estimatedMonthlyCost) }}
+              </td>
+              <td class="text-muted">{{ row.dataSource }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="d-flex align-items-center mb-4">
+        <b-button variant="outline-primary" size="sm" :disabled="loading" @click="fetchCostAttribution">
+          Refresh estimates
+        </b-button>
+        <b-button variant="link" size="sm" class="ml-2" @click="resetCostOverrides">
+          Reset unit costs
+        </b-button>
+      </div>
+
+      <section class="cost-assumptions">
+        <h2>Assumptions</h2>
+        <ul>
+          <li>Estimates are calculated in this browser from the resources currently returned by the console APIs.</li>
+          <li>Firmware builds use the recent build log returned by /logs/build as the current monthly usage signal.</li>
+          <li>Unit costs are local browser overrides and are not saved to the THiNX backend.</li>
+        </ul>
+      </section>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapActions, mapGetters, mapState } from 'vuex';
+
+export default {
+  name: 'CostAttribution',
+  computed: {
+    ...mapState('costAttribution', {
+      loading: state => state.loading,
+      error: state => state.error,
+      lastLoadedAt: state => state.lastLoadedAt,
+    }),
+    ...mapGetters('costAttribution', ['rows', 'totalMonthlyEstimate']),
+  },
+  created() {
+    this.fetchCostAttribution();
+  },
+  methods: {
+    ...mapActions('costAttribution', {
+      fetchCostAttribution: 'fetchItems',
+      updateUnitCost: 'updateUnitCost',
+      resetUnitCosts: 'resetUnitCosts',
+    }),
+    updateCost(key, value) {
+      if (value === '') {
+        return;
+      }
+      this.updateUnitCost({ key, value });
+    },
+    resetCostOverrides() {
+      this.resetUnitCosts();
+    },
+    formatCurrency(value) {
+      const numberValue = Number(value) || 0;
+      return '$' + numberValue.toLocaleString(undefined, {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      });
+    },
+    formatUnitCost(value) {
+      return String(Number(value) || 0);
+    },
+    formatDate(value) {
+      if (!value) {
+        return '';
+      }
+      return new Date(value).toLocaleString();
+    },
+    pluralize(label, quantity) {
+      if (quantity === 1) {
+        return label;
+      }
+      if (label === 'recent build') {
+        return 'recent builds';
+      }
+      return label + 's';
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.cost-attribution {
+  .cost-summary {
+    border-left: 4px solid #21ae8c;
+    padding: 16px 20px;
+    background: #fff;
+  }
+
+  .cost-summary__label {
+    color: #6c757d;
+    font-size: 0.875rem;
+    text-transform: uppercase;
+  }
+
+  .cost-summary__value {
+    color: #29323a;
+    font-size: 2rem;
+    font-weight: 600;
+    line-height: 1.2;
+    margin-top: 4px;
+  }
+
+  .cost-summary__meta {
+    color: #6c757d;
+    margin-top: 4px;
+  }
+
+  .cost-table th,
+  .cost-table td {
+    vertical-align: middle;
+  }
+
+  .cost-table__unit {
+    min-width: 150px;
+    width: 180px;
+  }
+
+  .cost-assumptions {
+    max-width: 820px;
+  }
+
+  .cost-assumptions h2 {
+    font-size: 1.25rem;
+  }
+}
+</style>

--- a/vue/src/store/costAttribution.js
+++ b/vue/src/store/costAttribution.js
@@ -1,0 +1,232 @@
+const STORAGE_KEY = 'thinx.costAttribution.unitCosts';
+
+export const DEFAULT_PRICE_CARD = {
+  devices: 0.1,
+  repositories: 1.5,
+  firmwareBuilds: 0.25,
+  apiKeys: 0.05,
+  environmentVariables: 0.01,
+  meshChannels: 0.2,
+  transformers: 0.1,
+};
+
+export const COST_COMPONENTS = [
+  {
+    key: 'devices',
+    component: 'Devices',
+    unitLabel: 'device',
+    dataSource: 'GET /device',
+  },
+  {
+    key: 'repositories',
+    component: 'Repositories',
+    unitLabel: 'repository',
+    dataSource: 'GET /source',
+  },
+  {
+    key: 'firmwareBuilds',
+    component: 'Firmware builds',
+    unitLabel: 'recent build',
+    dataSource: 'GET /logs/build',
+  },
+  {
+    key: 'apiKeys',
+    component: 'API keys',
+    unitLabel: 'key',
+    dataSource: 'GET /apikey',
+  },
+  {
+    key: 'environmentVariables',
+    component: 'Environment variables',
+    unitLabel: 'variable',
+    dataSource: 'GET /env',
+  },
+  {
+    key: 'meshChannels',
+    component: 'Mesh channels',
+    unitLabel: 'channel',
+    dataSource: 'GET /mesh',
+  },
+  {
+    key: 'transformers',
+    component: 'Transformers',
+    unitLabel: 'transformer',
+    dataSource: 'GET /profile info.transformers',
+  },
+];
+
+function cloneDefaultPriceCard() {
+  return { ...DEFAULT_PRICE_CARD };
+}
+
+function asArray(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (value && typeof value === 'object') {
+    return Object.keys(value).map(key => value[key]);
+  }
+  return [];
+}
+
+function normalizeCost(value, fallback) {
+  const numberValue = Number(value);
+  if (!Number.isFinite(numberValue) || numberValue < 0) {
+    return fallback;
+  }
+  return numberValue;
+}
+
+function roundCurrency(value) {
+  return Number((Number(value) || 0).toFixed(2));
+}
+
+function getStoredUnitCosts() {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return {};
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return {};
+    }
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch (error) {
+    return {};
+  }
+}
+
+function persistUnitCosts(unitCosts) {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return;
+  }
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(unitCosts));
+}
+
+function mergeUnitCosts(overrides) {
+  const merged = cloneDefaultPriceCard();
+  Object.keys(merged).forEach(key => {
+    if (Object.prototype.hasOwnProperty.call(overrides, key)) {
+      merged[key] = normalizeCost(overrides[key], merged[key]);
+    }
+  });
+  return merged;
+}
+
+export function loadUnitCosts() {
+  return mergeUnitCosts(getStoredUnitCosts());
+}
+
+export function normalizeResourceCounts(rootState) {
+  const state = rootState || {};
+
+  return {
+    devices: asArray(state.devices && state.devices.items).length,
+    repositories: asArray(state.repositories && state.repositories.items).length,
+    firmwareBuilds: asArray(state.buildlog && state.buildlog.items).length,
+    apiKeys: asArray(state.apikeys && state.apikeys.items).length,
+    environmentVariables: asArray(state.enviros && state.enviros.items).length,
+    meshChannels: asArray(state.channels && state.channels.items).length,
+    transformers: asArray(state.transformers && state.transformers.items).length,
+  };
+}
+
+export function buildCostRows(rootState, unitCosts) {
+  const counts = normalizeResourceCounts(rootState);
+  const costs = mergeUnitCosts(unitCosts || {});
+
+  return COST_COMPONENTS.map(component => {
+    const quantity = counts[component.key] || 0;
+    const unitCost = normalizeCost(costs[component.key], DEFAULT_PRICE_CARD[component.key]);
+
+    return {
+      ...component,
+      quantity,
+      unitCost,
+      estimatedMonthlyCost: roundCurrency(quantity * unitCost),
+    };
+  }).sort((a, b) => {
+    if (b.estimatedMonthlyCost !== a.estimatedMonthlyCost) {
+      return b.estimatedMonthlyCost - a.estimatedMonthlyCost;
+    }
+    return a.component.localeCompare(b.component);
+  });
+}
+
+export default {
+  namespaced: true,
+  state: {
+    loading: false,
+    error: null,
+    unitCosts: cloneDefaultPriceCard(),
+    lastLoadedAt: null,
+  },
+  mutations: {
+    setLoading(state, loading) {
+      state.loading = loading;
+    },
+    setError(state, error) {
+      state.error = error;
+    },
+    setUnitCosts(state, unitCosts) {
+      state.unitCosts = mergeUnitCosts(unitCosts || {});
+    },
+    setUnitCost(state, { key, value }) {
+      if (!Object.prototype.hasOwnProperty.call(state.unitCosts, key)) {
+        return;
+      }
+      state.unitCosts = {
+        ...state.unitCosts,
+        [key]: normalizeCost(value, state.unitCosts[key]),
+      };
+    },
+    setLastLoadedAt(state, lastLoadedAt) {
+      state.lastLoadedAt = lastLoadedAt;
+    },
+  },
+  actions: {
+    async fetchItems({ commit, dispatch }) {
+      commit('setLoading', true);
+      commit('setError', null);
+      commit('setUnitCosts', loadUnitCosts());
+
+      try {
+        await Promise.all([
+          dispatch('devices/fetchItems', null, { root: true }),
+          dispatch('repositories/fetchItems', null, { root: true }),
+          dispatch('buildlog/fetchBuildLog', null, { root: true }),
+          dispatch('apikeys/fetchItems', null, { root: true }),
+          dispatch('enviros/fetchItems', null, { root: true }),
+          dispatch('channels/fetchItems', null, { root: true }),
+          dispatch('transformers/fetchItems', null, { root: true }),
+        ]);
+        commit('setLastLoadedAt', new Date().toISOString());
+      } catch (error) {
+        commit(
+          'setError',
+          error && error.message ? error.message : 'Failed to load cost attribution resources.'
+        );
+      } finally {
+        commit('setLoading', false);
+      }
+    },
+    updateUnitCost({ commit, state }, { key, value }) {
+      commit('setUnitCost', { key, value });
+      persistUnitCosts(state.unitCosts);
+    },
+    resetUnitCosts({ commit, state }) {
+      commit('setUnitCosts', cloneDefaultPriceCard());
+      persistUnitCosts(state.unitCosts);
+    },
+  },
+  getters: {
+    rows(state, getters, rootState) {
+      return buildCostRows(rootState, state.unitCosts);
+    },
+    totalMonthlyEstimate(state, getters) {
+      return roundCurrency(getters.rows.reduce((total, row) => total + row.estimatedMonthlyCost, 0));
+    },
+  },
+};

--- a/vue/src/store/devices.js
+++ b/vue/src/store/devices.js
@@ -48,19 +48,19 @@ export default {
         if (result.success) await dispatch('fetchItems');
         return result;
       },
-      async pushConfiguration({ dispatch }, { udids, enviros, reset_devices }) {
+      async pushConfiguration({ dispatch: _dispatch }, { udids, enviros, reset_devices }) {
         const result = await this.$api.$post('/device/configuration', JSON.stringify({ udids, enviros, reset_devices }));
         return result;
       },
-      async buildFirmware({ dispatch }, { udid, source_id }) {
+      async buildFirmware({ dispatch: _dispatch }, { udid, source_id }) {
         const result = await this.$api.$post('/build', JSON.stringify({ build: { udid, source_id, dryrun: false } }));
         return result;
       },
-      async transferDevices({ dispatch }, { udids, to, mig_sources, mig_apikeys }) {
+      async transferDevices({ dispatch: _dispatch }, { udids, to, mig_sources, mig_apikeys }) {
         const result = await this.$api.$post('/transfer/request', JSON.stringify({ udids, to, mig_sources, mig_apikeys }));
         return result;
       },
-      async updateDevice({ dispatch }, { udid, changes }) {
+      async updateDevice({ dispatch: _dispatch }, { udid, changes }) {
         // PUT /api/v2/device -> editDevice. POST is getDeviceDetail (read).
         // editDevice reads req.body.changes and requires changes.udid.
         const result = await this.$api.$put('/device', JSON.stringify({ changes: { udid, ...changes } }));

--- a/vue/src/store/index.js
+++ b/vue/src/store/index.js
@@ -17,6 +17,7 @@ import buildlog from './buildlog';
 import auditlog from './auditlog.js';
 
 import stats from './stats.js';
+import costAttribution from './costAttribution';
 
 Vue.use(Vuex);
 
@@ -39,6 +40,7 @@ export default new Vuex.Store({
     auditlog,
 
     stats,
+    costAttribution,
     admin
   }
 });


### PR DESCRIPTION
## Scope
- Added a client-side Vuex costAttribution module that loads existing console resources and estimates monthly component costs from devices, repositories, recent firmware builds, API keys, environment variables, mesh channels, and transformers.
- Added the Cost Attribution Vue page with loading/error handling, total estimate, editable unit-cost inputs persisted in localStorage, per-component estimates, and assumptions.
- Registered the route at /app/cost-attribution and added Sidebar navigation under Summary.
- Added Cypress smoke coverage for rendering rows and updating/persisting a unit-cost override.
- Fixed Vue auth cold-start rehydration so protected hash routes can load from stored tokens, and adjusted lint compatibility for existing modern syntax.

## Validation
- cd vue && npm run lint
- cd vue && npx start-server-and-test serve http://127.0.0.1:3000/ "npx cypress run --spec cypress/integration/cost-attribution.spec.js"
- cd vue && npm run build

Build completed with existing Browserslist/Sass deprecation and bundle-size warnings.