### PR TITLE
docs: audit & fix guide/skill documentation

### DIFF
--- a/.planning/GUIDE-SKILL-IMPROVEMENTS.md
+++ b/.planning/GUIDE-SKILL-IMPROVEMENTS.md
@@ -1,0 +1,112 @@
+# Guide & Skill Documentation — Improvement Report
+
+**Audit date:** 2026-06-07
+**Branch:** `nightshift/guide-improver`
+**Scope:** Human- and agent-facing guide/skill documentation in `services/console`
+**Task:** Nightshift `guide-improver`
+
+## Files audited
+
+| File | Type | Verdict |
+|------|------|---------|
+| `README.md` | Build/test/commit guide | Fixes applied + recommendations |
+| `dev/README.md` | Dev-env stub (deprecated) | Recommendation |
+| `vue-dev/README.md` | Dev-env stub (deprecated) | Recommendation |
+| `dev/TASK_GROOMING.md` | Task-template guide | OK — accurate |
+| `IMPROVEMENTS.md` | Deferred-work log | OK — accurate |
+| `IMPLEMENTATION_PLAN.md` | Migration plan | Recommendation |
+| `.planning/PROJECT.md` | Living project constitution | OK — already correct |
+| `.planning/ROADMAP.md` | Milestone roadmap | Fix applied |
+| `.planning/v1.x-backlog.md` | Operational backlog | Fix applied |
+| `.planning/` phase-N docs | Historical GSD artifacts | Left intact (see F-06) |
+
+No `AGENTS.md`, `CLAUDE.md`, or `docs/` directory exists in this repo. The
+memory note `swarm-deploy-script-name` references an `AGENTS.md` docs fix; the
+equivalent live error actually lived in `.planning/v1.x-backlog.md` (see F-03).
+
+---
+
+## Applied fixes (safe, verifiable)
+
+### F-01 — README build command: backslash + missing context — `README.md:18` — MEDIUM
+**Was:** `docker build -t yourname\console`
+**Now:** `docker build -t yourname/console .`
+Windows-style backslash made the tag invalid on the documented (Linux/macOS)
+toolchain, and the build context (`.`) was missing entirely. Verifiable typo.
+
+### F-02 — README test example malformed + non-existent script — `README.md:38` — MEDIUM
+**Was:** `docker run -ti -v $(pwd):/var/work thinxcloud/console-build-env:vue cd /var/work && npm run test:unit`
+**Now:** `docker run -ti -v $(pwd):/var/work thinxcloud/console-build-env:vue bash -c "cd /var/work/vue && yarn && yarn test"`
+Three defects: (1) `cd /var/work` was passed as the container's command (not a
+valid binary); (2) `&& npm run test:unit` ran on the **host**, not the
+container; (3) there is **no** `test:unit` script — `vue/package.json` defines
+`test` (`start-server-and-test serve … cy:test`), and CI (`.circleci/config.yml`
+`test_vue`) runs `yarn test` from `vue/`. New form mirrors CI.
+
+### F-03 — Swarm deploy script name — `.planning/v1.x-backlog.md:117,121` — LOW
+**Was:** `./scripts/stack-deploy` / `stack-deploy`
+**Now:** `./restart.sh`
+The real swarm-host script on `188.166.23.244` is `./restart.sh` (memory
+`swarm-deploy-script-name`). `.planning/PROJECT.md:101` already documents the
+correct name and flags the discrepancy; the backlog still carried the wrong
+name. Now consistent.
+
+### F-04 — Legacy GSD colon command syntax — `.planning/ROADMAP.md:9,70` — LOW
+**Was:** `/gsd:plan-phase`
+**Now:** `/gsd-plan-phase`
+Project standard is the hyphen form; colon is legacy (memory
+`gsd-command-syntax-hyphen`). These are forward-looking operator instructions,
+not historical records. Line 70 was internally inconsistent — it already used
+the hyphen form `/gsd-new-milestone` in the same sentence.
+
+---
+
+## Recommendations (not auto-applied — need owner judgement)
+
+### F-05 — Stale Vue deploy URL — `IMPLEMENTATION_PLAN.md:5` — LOW
+Header states Vue console is "deployed at staging.thinx.cloud". The current
+deploy target is `console.thinx.cloud` (`.planning/PROJECT.md:17`). This is a
+dated (2026-03-14) plan header; left untouched because the staging URL may be an
+accurate historical record. Recommend updating the live target or annotating it
+as historical.
+
+### F-06 — Legacy `/gsd:` colon syntax across historical phase docs — INFO
+The colon form persists in many `.planning/phase-*/` RESEARCH/VALIDATION docs
+(e.g. `phase-4/04-RESEARCH.md`, `phase-8/08-RESEARCH.md`). These are immutable
+historical artifacts and were deliberately **not** rewritten. Recommendation:
+use the hyphen form in all new docs; do not retroactively edit completed phases.
+
+### F-07 — Duplicate deprecated dev-env stubs — `dev/README.md`, `vue-dev/README.md` — LOW
+Both files are byte-identical ("THiNX Console Development Environment —
+Deprecated") and carry trailing whitespace. Recommend consolidating to a single
+canonical stub (or deleting the redundant `vue-dev/README.md`) to avoid drift.
+
+### F-08 — Outdated "until this is documented" clause — `README.md:9` — LOW
+The Usage section says to read `.circleci/config.yml` for build-args "until this
+is documented" — but the build-args **are** documented in the table immediately
+below. Recommend dropping the clause.
+
+### F-09 — Dead status badges — `README.md:3` — LOW
+The README links an `lgtm.com` alerts badge. LGTM.com was retired by GitHub in
+2022, so the badge is permanently broken. Recommend removing the LGTM badge
+(FOSSA badges remain valid).
+
+---
+
+## Verified-correct (no change — documented to prevent future regressions)
+
+### F-10 — `WEB_HOSTNAME` default `rtm.thinx.cloud` — `README.md:25`
+Looks inconsistent with the `console.thinx.*` example, but is **correct**: the
+legacy console deploys to `rtm.thinx.cloud` (`src/package.json` `build:test`
+sets `WEB_HOSTNAME=https://rtm.thinx.cloud`; `IMPLEMENTATION_PLAN.md:4` and
+`PROJECT.md:71` confirm). Do not "fix" this to `console.thinx.cloud`.
+
+---
+
+## Summary
+
+- **4 fixes applied** (F-01..F-04): 2 in `README.md`, 1 in `.planning/v1.x-backlog.md`, 1 in `.planning/ROADMAP.md`.
+- **5 recommendations** (F-05..F-09) left for owner judgement.
+- **1 false-positive documented** (F-10) so it is not mistakenly "corrected" later.
+- All applied changes verified against the live repo (`.circleci/config.yml`,
+  `vue/package.json`, `src/package.json`) and project memory.

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -6,7 +6,7 @@
 ## Milestones
 
 - ✅ **v1.999 Feature-Parity GA** — Phases 1-11 (shipped 2026-05-27)
-- 🚧 **v1.x Operational Hygiene** — Phase 1 scheduled 2026-06-03 (SEC-DEP-02 cross-project triage from `thinx-device-api` v1.9 Phase 10); execution awaits operator `/gsd:plan-phase`.
+- 🚧 **v1.x Operational Hygiene** — Phase 1 scheduled 2026-06-03 (SEC-DEP-02 cross-project triage from `thinx-device-api` v1.9 Phase 10); execution awaits operator `/gsd-plan-phase`.
 
 Archives: [v1.999-ROADMAP.md](./milestones/v1.999-ROADMAP.md), [v1.999-REQUIREMENTS.md](./milestones/v1.999-REQUIREMENTS.md)
 Full shipped scope: [MILESTONES.md](./MILESTONES.md)
@@ -67,7 +67,7 @@ Run `/gsd-new-milestone` to scope v1.x — backlog candidates in `.planning/v1.x
   3. services/console CI green on the resulting branch (typically `thinx-staging`) — the Vue console build (`npm run build:test` or equivalent) still completes without referencing the deleted manifest.
   4. The parent `thinx-device-api` submodule pointer for `services/console` bumps cleanly across the SEC-DEP-02 commit; parent CircleCI stays green across the pointer-bump commit on `thinx-staging`.
 
-**Plans:** TBD (operator runs `/gsd:plan-phase 1` in this GSD workspace after `/gsd-new-milestone` is run for `v1.x Operational Hygiene`).
+**Plans:** TBD (operator runs `/gsd-plan-phase 1` in this GSD workspace after `/gsd-new-milestone` is run for `v1.x Operational Hygiene`).
 
 **Cross-project references:**
 - Parent project verdict roll-up: `thinx-device-api/.planning/dep-triage.md` § "Phase 10 / SEC-DEP-02 (services/console) — Cross-Project Roll-up" (2 rows; both `deferred-vendored-asset`).

--- a/.planning/v1.x-backlog.md
+++ b/.planning/v1.x-backlog.md
@@ -114,11 +114,11 @@ Every recent build attempt fails at the same point: `[arduino] Docker build fail
 
 ## OPS-swarmpull: Diagnose swarm auto-pull failure
 
-**Source:** 2026-05-25 / 2026-05-26 incident — parent CI pipelines 5213 + 5214 + 5215 each succeeded but the swarm did not pull the new `thinx/console:vue` image. Manual `./scripts/stack-deploy` on swarm manager fixed it. Auto-pull worked previously (parent commit `96e8e144` at 14:44 CET on 2026-05-25 deployed automatically within minutes).
+**Source:** 2026-05-25 / 2026-05-26 incident — parent CI pipelines 5213 + 5214 + 5215 each succeeded but the swarm did not pull the new `thinx/console:vue` image. Manual `./restart.sh` on swarm manager fixed it. Auto-pull worked previously (parent commit `96e8e144` at 14:44 CET on 2026-05-25 deployed automatically within minutes).
 **Estimate:** Unknown — could be small if it's a stopped Watchtower container; could be large if it's a registry / network / image-tag / credential config issue.
 **Status:** Captured (operational)
 
-Until this is fixed, every Vue console deploy requires manual `stack-deploy` on the swarm manager — error-prone and adds latency to the dev loop.
+Until this is fixed, every Vue console deploy requires manual `./restart.sh` on the swarm manager — error-prone and adds latency to the dev loop.
 
 **Investigation hints:**
 - `docker ps -a | grep -i watch` on each swarm node — is Watchtower (or equivalent) container alive?

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Note: For task grooming and standardized task templates, see `dev/TASK_GROOMING.
 
 ## Build Configuration
 
-You can build your own image using `docker build -t yourname\console` and following environment variables will be injected to static HTML on build:
+You can build your own image using `docker build -t yourname/console .` and following environment variables will be injected to static HTML on build:
 
 | Variable name          | Example                          | Purpose                          | Default                 |
 |:-----------------------|:---------------------------------|:---------------------------------|:------------------------|
@@ -35,7 +35,7 @@ You can build your own image using `docker build -t yourname\console` and follow
 
 Example:
     
-    docker run -ti -v $(pwd):/var/work thinxcloud/console-build-env:vue cd /var/work && npm run test:unit
+    docker run -ti -v $(pwd):/var/work thinxcloud/console-build-env:vue bash -c "cd /var/work/vue && yarn && yarn test"
 
 
 ## Commit Convention


### PR DESCRIPTION
## Summary

Nightshift `guide-improver` audit of human- and agent-facing guide/skill docs in `services/console`. Applied 4 safe, verifiable corrections and recorded the full findings set (incl. recommendations not auto-applied) in `.planning/GUIDE-SKILL-IMPROVEMENTS.md`.

## Files audited
`README.md`, `dev/README.md`, `vue-dev/README.md`, `dev/TASK_GROOMING.md`, `IMPROVEMENTS.md`, `IMPLEMENTATION_PLAN.md`, `.planning/PROJECT.md`, `.planning/ROADMAP.md`, `.planning/v1.x-backlog.md`, `.planning/` phase-N docs. (No `AGENTS.md`/`CLAUDE.md`/`docs/` exist.)

## Applied fixes
- **README.md** - `docker build -t yourname\console` -> `yourname/console .` (invalid backslash tag + missing build context).
- **README.md** - Testing-in-Docker example was broken: `cd` ran as the container command, `&& npm run test:unit` ran on the host, and `test:unit` does not exist. Replaced with a working invocation that mirrors CI (`yarn test`).
- **.planning/v1.x-backlog.md** - swarm deploy script `./scripts/stack-deploy` -> `./restart.sh` (matches `PROJECT.md` + project memory).
- **.planning/ROADMAP.md** - legacy GSD colon syntax `/gsd:plan-phase` -> hyphen `/gsd-plan-phase`.

All edits verified against `.circleci/config.yml`, `vue/package.json`, and `src/package.json`.

## Outstanding recommendations (not auto-applied)
- `IMPLEMENTATION_PLAN.md:5` stale deploy URL (`staging.thinx.cloud` vs `console.thinx.cloud`).
- Legacy `/gsd:` colon syntax in historical phase docs - left as records.
- Duplicate deprecated stubs `dev/README.md` / `vue-dev/README.md`.
- README "until this is documented" clause is obsolete; dead LGTM badge.
- Documented one **false positive** (`WEB_HOSTNAME` default `rtm.thinx.cloud` is correct for legacy) to prevent future bad "fixes".

Generated with Claude Code

Nightshift-Task: guide-improver
Nightshift-Ref: https://github.com/marcus/nightshift


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: guide-improver:/Users/igraczech/Repositories/thinx-device-api/services/console
task-type: guide-improver
task-title: Guide/Skill Improver
iterations: 1
duration: 7m40s
nightshift:metadata -->
