### PR TITLE
docs: synthesize changelog from recent commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,28 @@ Changes are grouped by release date and conventional-commit type.
 
 ---
 
+## [2026-06] — Login UX & Dependency Hygiene
+
+### Added
+- Legacy login, register, forgot-password, and password-reset forms now disable their submit buttons and show spinner feedback while requests are in flight to prevent accidental double submits.
+
+### Changed
+- Vue login OAuth buttons now use brand-correct Google and GitHub styling with rounded button spacing.
+
+### Fixed
+- **AUTH-RESET-ORIGIN**: Vue password-reset initialization now sends `client=vue` so reset links route back to the Vue console.
+
+### Security
+- **SEC-DEP-02**: Removed unused vendored `jquery-validation` package metadata that caused high-severity Grunt Dependabot alerts, without changing the shipped static assets.
+
+### Developer Tooling
+- Added Commitlint and a Husky `commit-msg` hook to enforce conventional commit messages.
+
+### Internal / Planning
+- **SEC-DEP-02**: Scheduled the dependency-hygiene phase coordinated from thinx-device-api v1.9.
+
+---
+
 ## [2026-05-19] — Phase 2 Feature Completion
 
 ### Added


### PR DESCRIPTION
## Summary
- refreshed CHANGELOG.md with missing June 2026 entries from recent non-merge commits
- covered login double-submit feedback, OAuth button styling, Vue password-reset client tagging, SEC-DEP-02 vendored metadata removal, commitlint/Husky tooling, and SEC-DEP-02 planning
- omitted merge commits and the prior docs-only changelog generation commit 735bded

## Scope
- documentation-only change to CHANGELOG.md
- left existing untracked .planning/INBOX-TRIAGE.md untouched

## Verification
- git diff --check: passed
- app build/tests skipped because no application files changed


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: changelog-synth:/Users/igraczech/Repositories/thinx-device-api/services/console
task-type: changelog-synth
task-title: Changelog Synthesizer
iterations: 1
duration: 5m30s
nightshift:metadata -->
