### PR TITLE
feat(doc-drift): documentation drift detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can build your own image using `docker build -t yourname\console` and follow
 
 Example:
     
-    docker run -ti -v $(pwd):/var/work thinxcloud/console-build-env:vue cd /var/work && npm run test:unit
+    docker run -ti -v $(pwd):/var/work thinxcloud/console-build-env:vue cd /var/work && npm run test
 
 
 ## Documentation Drift Check

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ Example:
     docker run -ti -v $(pwd):/var/work thinxcloud/console-build-env:vue cd /var/work && npm run test:unit
 
 
+## Documentation Drift Check
+
+`scripts/doc-drift.js` is a zero-dependency Node script that flags docs which have
+drifted from the code: broken relative paths, references to npm scripts that no
+longer exist, and missing source paths in code blocks. Run it from the repo root
+with `node scripts/doc-drift.js`, or from the `vue/` project with `npm run doc-drift`.
+It exits non-zero on drift, so it can gate CI. See `scripts/README.md` for details
+and how to suppress intentional examples.
+
 ## Commit Convention
 
 Commits must follow [Conventional Commits](https://www.conventionalcommits.org/) format:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,42 @@
+# scripts/
+
+Maintenance scripts for the THiNX console repo. Zero npm dependencies — plain Node.
+
+## doc-drift.js — documentation drift detector
+
+Catches docs that have fallen out of sync with the code. It scans the markdown
+docs (`README.md`, `AGENTS.md`, `CLAUDE.md`, and `docs/*.md`) for three
+high-signal drift indicators:
+
+| Check            | What it flags                                                                 |
+|:-----------------|:------------------------------------------------------------------------------|
+| `broken-link`    | A relative file/dir path referenced in prose (markdown links + inline code) that no longer exists on disk. |
+| `unknown-script` | An `npm`/`yarn`/`pnpm run <name>` reference whose script is absent from **every** `package.json` in the repo. |
+| `missing-source` | A source path inside a fenced code block that points into the repo but does not exist. |
+
+A path is only checked when its first segment is a real top-level entry (e.g.
+`src/`, `vue/`, `.circleci/`) or when it is explicitly `./` / `../` relative.
+This keeps npm package names, URLs, and shell variables out of the results
+without an ever-growing allowlist. Legacy AngularJS paths under `src/` are
+treated as live (legacy is supported until the Vue console ships as v2.0.x).
+
+### Running it
+
+```
+# from the repo root
+node scripts/doc-drift.js
+
+# or via the vue/ project
+cd vue && npm run doc-drift
+```
+
+It exits `1` when drift is found and `0` when clean, so it can gate CI.
+
+### Suppressing intentional examples
+
+False positives (deliberate examples, placeholder paths) can be silenced:
+
+- Put `<!-- doc-drift-ignore -->` on the offending line, or on the line directly
+  above it.
+- Put `<!-- doc-drift-ignore-file -->` anywhere in a file to skip the whole file.
+- Add a substring to the `ALLOWLIST` array near the top of `scripts/doc-drift.js`.

--- a/scripts/doc-drift.js
+++ b/scripts/doc-drift.js
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+'use strict';
+
+/*
+ * doc-drift.js — zero-dependency documentation drift detector for the THiNX console.
+ *
+ * Scans markdown docs (README.md, AGENTS.md, CLAUDE.md, docs/*.md) for three
+ * high-signal drift indicators:
+ *
+ *   1. broken-link     — a relative file/dir path referenced in the docs that no
+ *                        longer exists on disk (markdown links + inline-code paths).
+ *   2. unknown-script  — an `npm/yarn/pnpm run <name>` reference whose script name
+ *                        is absent from every package.json in the repo.
+ *   3. missing-source  — a source path (inside a fenced code block) that points
+ *                        into the repo but does not exist.
+ *
+ * Design notes:
+ *   - No npm dependencies (project convention). Node built-ins only.
+ *   - Self-locating: the repo root is the parent of this script's directory, so
+ *     it runs correctly from any working directory.
+ *   - Legacy AngularJS paths under src/ are treated as live (legacy is supported
+ *     until the Vue console is GA'd as v2.0.x), so they are checked, not skipped.
+ *   - A path token is only treated as a repo reference when its first segment
+ *     matches a real top-level entry (or it is explicitly ./ or ../ relative).
+ *     This keeps npm package names (@scope/pkg), URLs and shell vars out of the
+ *     results without an ever-growing allowlist.
+ *
+ * Suppressing intentional examples / known false positives:
+ *   - Put `<!-- doc-drift-ignore -->` on the offending line or the line above it.
+ *   - Put `<!-- doc-drift-ignore-file -->` anywhere in a file to skip it entirely.
+ *   - Add a substring to the ALLOWLIST array below.
+ *
+ * Exit code: 1 when drift is found (CI-gating), 0 when clean.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+// Docs to scan (relative to repo root). Missing files are skipped silently.
+const DOC_FILES = ['README.md', 'AGENTS.md', 'CLAUDE.md'];
+const DOC_GLOB_DIRS = ['docs']; // every *.md under these dirs (recursively)
+
+// Substrings that suppress a finding for a path or script name. Keep this small;
+// prefer the inline `<!-- doc-drift-ignore -->` marker for one-off examples.
+const ALLOWLIST = [];
+
+const IGNORE_LINE = 'doc-drift-ignore';
+const IGNORE_FILE = 'doc-drift-ignore-file';
+
+// ---------------------------------------------------------------------------
+// Filesystem helpers
+// ---------------------------------------------------------------------------
+
+const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', 'coverage', '.nyc_output']);
+
+function walk(dir, matchFn, acc) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch (e) {
+    return acc;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      walk(full, matchFn, acc);
+    } else if (matchFn(full)) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+// Union of every script name defined in any package.json in the repo.
+function collectScriptNames() {
+  const names = new Set();
+  const pkgFiles = walk(ROOT, (f) => path.basename(f) === 'package.json', []);
+  for (const file of pkgFiles) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(file, 'utf8'));
+      if (pkg && pkg.scripts) {
+        for (const key of Object.keys(pkg.scripts)) names.add(key);
+      }
+    } catch (e) {
+      // Unparseable package.json — ignore for script resolution.
+    }
+  }
+  return names;
+}
+
+function collectDocs() {
+  const docs = [];
+  for (const rel of DOC_FILES) {
+    const full = path.join(ROOT, rel);
+    if (fs.existsSync(full)) docs.push(full);
+  }
+  for (const d of DOC_GLOB_DIRS) {
+    const dir = path.join(ROOT, d);
+    if (fs.existsSync(dir)) {
+      walk(dir, (f) => f.toLowerCase().endsWith('.md'), docs);
+    }
+  }
+  return docs;
+}
+
+const TOP_LEVEL = new Set(fs.readdirSync(ROOT));
+
+// ---------------------------------------------------------------------------
+// Path candidate extraction
+// ---------------------------------------------------------------------------
+
+const URL_RE = /^(https?:|ftp:|mailto:|tel:|data:|#)/i;
+// Characters that mark a token as a template/placeholder/shell expression.
+const PLACEHOLDER_RE = /[<>${}*\s|"'`]/;
+
+function stripDecorations(raw) {
+  let s = raw.trim();
+  // Drop trailing markdown / sentence punctuation.
+  s = s.replace(/[).,;:!?]+$/, '');
+  // Drop anchor / query suffixes.
+  s = s.replace(/[#?].*$/, '');
+  return s;
+}
+
+// Returns the absolute path to check, or null if the token is not a repo-relative
+// reference we should validate.
+function resolveCandidate(token, docDir) {
+  if (!token) return null;
+  if (URL_RE.test(token)) return null;
+  if (PLACEHOLDER_RE.test(token)) return null;
+  if (token.startsWith('@')) return null; // npm scoped package
+  if (path.isAbsolute(token)) return null; // container / system paths, not repo paths
+
+  if (token.startsWith('./') || token.startsWith('../')) {
+    return path.resolve(docDir, token);
+  }
+
+  // Must contain a path separator to be a path (excludes bare words like "feat").
+  if (!token.includes('/')) return null;
+
+  const firstSegment = token.split('/')[0];
+  // Only treat it as a repo reference when it points at a real top-level entry.
+  if (!TOP_LEVEL.has(firstSegment)) return null;
+
+  return path.resolve(ROOT, token);
+}
+
+function inAllowlist(value) {
+  return ALLOWLIST.some((entry) => value.includes(entry));
+}
+
+// ---------------------------------------------------------------------------
+// Per-line scanners
+// ---------------------------------------------------------------------------
+
+const MD_LINK_RE = /\[[^\]]*\]\(([^)\s]+)/g;
+const INLINE_CODE_RE = /`([^`]+)`/g;
+const SCRIPT_RE = /\b(?:npm|yarn|pnpm)\s+run\s+([A-Za-z0-9:_.\-]+)/g;
+// Path-like bare tokens inside fenced code blocks.
+const BARE_PATH_RE = /(?:\.{1,2}\/)?[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)+\/?/g;
+
+function extractPathTokens(line, inFence) {
+  const tokens = new Set();
+  let m;
+
+  MD_LINK_RE.lastIndex = 0;
+  while ((m = MD_LINK_RE.exec(line)) !== null) tokens.add(m[1]);
+
+  INLINE_CODE_RE.lastIndex = 0;
+  while ((m = INLINE_CODE_RE.exec(line)) !== null) {
+    // An inline-code span may hold a command ("npm run x") or a path. Split it
+    // and keep the path-looking pieces.
+    for (const piece of m[1].split(/\s+/)) {
+      if (piece.includes('/')) tokens.add(piece);
+    }
+  }
+
+  if (inFence) {
+    BARE_PATH_RE.lastIndex = 0;
+    while ((m = BARE_PATH_RE.exec(line)) !== null) tokens.add(m[0]);
+  }
+
+  return [...tokens];
+}
+
+function extractScriptRefs(line) {
+  const refs = [];
+  let m;
+  SCRIPT_RE.lastIndex = 0;
+  while ((m = SCRIPT_RE.exec(line)) !== null) refs.push(m[1]);
+  return refs;
+}
+
+// ---------------------------------------------------------------------------
+// Main scan
+// ---------------------------------------------------------------------------
+
+function scanDoc(file, scriptNames) {
+  const findings = [];
+  const text = fs.readFileSync(file, 'utf8');
+  if (text.includes(IGNORE_FILE)) return findings;
+
+  const lines = text.split(/\r?\n/);
+  const docDir = path.dirname(file);
+  let inFence = false;
+  const seen = new Set();
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    if (/^\s*(```|~~~)/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+
+    const prev = i > 0 ? lines[i - 1] : '';
+    const ignored = line.includes(IGNORE_LINE) || prev.includes(IGNORE_LINE);
+    if (ignored) continue;
+
+    const lineNo = i + 1;
+
+    // Check 2: npm/yarn script references.
+    for (const ref of extractScriptRefs(line)) {
+      if (scriptNames.has(ref) || inAllowlist(ref)) continue;
+      const key = lineNo + ':script:' + ref;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      findings.push({
+        line: lineNo,
+        type: 'unknown-script',
+        token: ref,
+        message: 'npm/yarn script "' + ref + '" is not defined in any package.json',
+      });
+    }
+
+    // Checks 1 & 3: filesystem path references.
+    for (const token of extractPathTokens(line, inFence)) {
+      const clean = stripDecorations(token);
+      if (inAllowlist(clean)) continue;
+      const resolved = resolveCandidate(clean, docDir);
+      if (resolved === null) continue;
+      if (fs.existsSync(resolved)) continue;
+
+      const type = inFence ? 'missing-source' : 'broken-link';
+      const key = lineNo + ':' + type + ':' + clean;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      findings.push({
+        line: lineNo,
+        type,
+        token: clean,
+        message: 'referenced path "' + clean + '" does not exist',
+      });
+    }
+  }
+
+  return findings;
+}
+
+function relRoot(file) {
+  return path.relative(ROOT, file) || path.basename(file);
+}
+
+function main() {
+  const scriptNames = collectScriptNames();
+  const docs = collectDocs();
+
+  if (docs.length === 0) {
+    console.log('doc-drift: no documentation files found to scan.');
+    process.exit(0);
+  }
+
+  let total = 0;
+  const byDoc = [];
+
+  for (const doc of docs) {
+    const findings = scanDoc(doc, scriptNames);
+    if (findings.length > 0) {
+      findings.sort((a, b) => a.line - b.line);
+      byDoc.push({ doc, findings });
+      total += findings.length;
+    }
+  }
+
+  console.log('doc-drift: documentation drift detector');
+  console.log('scanned ' + docs.length + ' doc file(s) against ' + scriptNames.size + ' known npm script(s)\n');
+
+  if (total === 0) {
+    console.log('No drift detected. Docs are in sync with the code. ✓');
+    process.exit(0);
+  }
+
+  for (const entry of byDoc) {
+    console.log(relRoot(entry.doc));
+    for (const f of entry.findings) {
+      console.log('  ' + f.line + '\t[' + f.type + '] ' + f.message);
+    }
+    console.log('');
+  }
+
+  console.log('Found ' + total + ' drift issue(s) across ' + byDoc.length + ' file(s).');
+  console.log('Fix the docs, or suppress intentional examples with a');
+  console.log('`<!-- doc-drift-ignore -->` marker (see scripts/README.md).');
+  process.exit(1);
+}
+
+main();

--- a/vue/package.json
+++ b/vue/package.json
@@ -11,6 +11,7 @@
     "cy:open": "cypress open",
     "test": "start-server-and-test serve http://127.0.0.1:3000/ cy:test",
     "eslint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore",
+    "doc-drift": "node ../scripts/doc-drift.js",
     "prepare": "cd .. && npx husky install"
   },
   "dependencies": {


### PR DESCRIPTION
## Doc Drift Detector

Adds a minimal, **zero-dependency** Node script that detects documentation that has fallen out of sync with the code. Runnable locally and CI-gateable (exits non-zero on drift).

### What it checks
`scripts/doc-drift.js` scans markdown docs (`README.md`, `AGENTS.md`, `CLAUDE.md`, `docs/*.md`) for three high-signal drift indicators:

| Check | Flags |
|:--|:--|
| `broken-link` | Relative file/dir paths in prose (markdown links + inline code) that no longer exist on disk |
| `unknown-script` | `npm`/`yarn`/`pnpm run <name>` references absent from **every** `package.json` in the repo |
| `missing-source` | Source paths inside fenced code blocks that point into the repo but do not exist |

A path is only checked when its first segment is a real top-level entry (e.g. `src/`, `vue/`, `.circleci/`) or is explicitly `./`/`../` relative — this keeps npm package names, URLs, and shell vars out of the results without a large allowlist. Legacy AngularJS paths under `src/` are treated as live (legacy supported until Vue ships as v2.0.x).

### Suppressing false positives
- `<!-- doc-drift-ignore -->` on or directly above the offending line
- `<!-- doc-drift-ignore-file -->` to skip a whole file
- `ALLOWLIST` array at the top of the script

### Wiring
- `node scripts/doc-drift.js` (repo root) or `npm run doc-drift` (from `vue/`)
- Documented in `README.md` and `scripts/README.md`

### Findings on the current tree
On first run the detector flagged a **genuine** drift:

```
README.md
  38   [unknown-script] npm/yarn script "test:unit" is not defined in any package.json
Found 1 drift issue(s) across 1 file(s).   (exit code 1)
```

The Docker testing example referenced `npm run test:unit`, which exists in no `package.json` (`vue/` defines `test`). The second commit corrects it, so the tree is now drift-clean:

```
No drift detected. Docs are in sync with the code.   (exit code 0)
```

### Verification
- `node --check scripts/doc-drift.js` → syntax OK
- Detection, ignore-marker suppression, and no-false-positive behavior verified against temp `docs/` fixtures
- No new npm dependencies (project convention)

Nightshift-Task: doc-drift
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)
