### PR TITLE
fix: select-all off-by-one + device-store lint errors (bug-finder)

### DIFF
--- a/vue/src/components/List/List.vue
+++ b/vue/src/components/List/List.vue
@@ -60,7 +60,9 @@ export default {
       return this.dataheaders.filter((h) => h.pos !== null);
     },
     isAllSelected() {
-      return this.selectedItems.length == this.datasource.length - 1 ? true : false;
+      // All rows selected only when every row is in selectedItems. Guard against an
+      // empty datasource so the header checkbox isn't shown checked with zero rows.
+      return this.datasource.length > 0 && this.selectedItems.length === this.datasource.length;
     },
   },
   methods: {

--- a/vue/src/store/devices.js
+++ b/vue/src/store/devices.js
@@ -48,19 +48,19 @@ export default {
         if (result.success) await dispatch('fetchItems');
         return result;
       },
-      async pushConfiguration({ dispatch }, { udids, enviros, reset_devices }) {
+      async pushConfiguration(_, { udids, enviros, reset_devices }) {
         const result = await this.$api.$post('/device/configuration', JSON.stringify({ udids, enviros, reset_devices }));
         return result;
       },
-      async buildFirmware({ dispatch }, { udid, source_id }) {
+      async buildFirmware(_, { udid, source_id }) {
         const result = await this.$api.$post('/build', JSON.stringify({ build: { udid, source_id, dryrun: false } }));
         return result;
       },
-      async transferDevices({ dispatch }, { udids, to, mig_sources, mig_apikeys }) {
+      async transferDevices(_, { udids, to, mig_sources, mig_apikeys }) {
         const result = await this.$api.$post('/transfer/request', JSON.stringify({ udids, to, mig_sources, mig_apikeys }));
         return result;
       },
-      async updateDevice({ dispatch }, { udid, changes }) {
+      async updateDevice(_, { udid, changes }) {
         // PUT /api/v2/device -> editDevice. POST is getDeviceDetail (read).
         // editDevice reads req.body.changes and requires changes.udid.
         const result = await this.$api.$put('/device', JSON.stringify({ changes: { udid, ...changes } }));


### PR DESCRIPTION
## Summary

Autonomous bug-finding pass over the Vue console (`services/console/vue`). Candidates were surfaced with `eslint` + `vue-cli-service build` and targeted review of fragile areas (api client, auth/session, router guards, reactivity/selection logic). Two high-confidence, well-scoped fixes are included. No new dependencies; the legacy AngularJS console (`services/console/src`) is untouched.

## Bugs fixed

### 1. Select-all checkbox off-by-one (`List.vue`) — functional bug
`isAllSelected` returned `true` only when `selectedItems.length === datasource.length - 1`:

```js
return this.selectedItems.length == this.datasource.length - 1 ? true : false;
```

**Effect:** the header "select all" checkbox *unchecked itself* the instant every row became selected, and falsely showed *checked* when exactly one row short. The shared `List` component drives the select-all control on **Apikeys, Repositories, Rsakeys, Enviros, and Channels**.

**Root cause:** the spurious `- 1` (plus loose `==`). `Devices.vue` already has the correct reference implementation (`filteredItems.length > 0 && filteredItems.every(...)`).

**Fix:** compare against the full length with an empty-datasource guard:
```js
return this.datasource.length > 0 && this.selectedItems.length === this.datasource.length;
```
Verified against all trigger states: all-selected -> `true`; N-1 selected -> `false`; empty list -> `false`.

### 2. Unused `dispatch` context in device store (`devices.js`) — lint failure
`pushConfiguration`, `buildFirmware`, `transferDevices`, and `updateDevice` destructured `{ dispatch }` from the Vuex context but never used it, producing four `no-unused-vars` errors that made `npm run lint` exit non-zero. Replaced with the ignored-arg placeholder `_`; Vuex still passes context positionally, so behaviour is unchanged.

## Verification
- `npm run build` — passes (clean compile, before and after).
- `npm run lint` — all four `devices.js` errors cleared. The 4 remaining `Parsing error: Unexpected token` entries (App.vue, Login.vue, TransformerEditor.vue, vue.config.js) are **pre-existing** — the configured eslint parser does not understand optional chaining / object spread; they were present before this branch and the build compiles that syntax fine. Out of scope.
- No Cypress spec exercises the changed selection logic or device actions; the selection fix is pure synchronous logic reasoned through above.

## Notes / not changed
- `App.vue`'s cold-reload rehydration block (`if (authenticated)`) is effectively dead on a hard reload because it gates on the in-memory `isAuthenticated` getter before the store is hydrated. In practice the flow self-corrects via `Login.vue`'s `created()` bounce, so it is **not** user-facing broken. This is delicate, Phase-8-tuned session logic, so it was deliberately left alone rather than risk a regression in a bug-finding pass.

Nightshift-Task: bug-finder
Nightshift-Ref: https://github.com/marcus/nightshift

Generated with Claude Code
