### PR TITLE
Fix browser security foot-guns in console

### DIFF
--- a/src/app/views/device.html
+++ b/src/app/views/device.html
@@ -217,14 +217,15 @@
                 <span class="badge {{source.value.base_platform}}-platform-color platform-badge">{{$root.platforms[source.value.base_platform].name}}</span>
               </div>
               <small>{{source.value.url}}</small>
-              <div ng-if="source.value.circle_key.length > 0">
-                <img src="https://circleci.com/gh/{{source.value.url | split:'git@github.com:':1 | split:'.git':0 }}.svg?style=svg&circle-token={{source.value.circle_key}}" />
+              <div ng-if="source.value.circle_key">
+                <span class="badge badge-info" title="CircleCI token configured">CircleCI token configured</span>
+                <img ng-src="https://circleci.com/gh/{{source.value.url | split:'git@github.com:':1 | split:'.git':0 }}.svg?style=svg" alt="CircleCI build status" />
               </div>
             </ui-select-choices>
           </ui-select>
           <span class="input-group-btn">
             <button ng-if="$root.getSourceById(deviceForm.source).circle_key" type="button" class="btn btn-default">
-              <img src="https://circleci.com/gh/{{$root.getSourceById(deviceForm.source).url | split:'git@github.com:':1 | split:'.git':0 }}.svg?style=svg&circle-token={{$root.getSourceById(deviceForm.source).circle_key}}" />
+              <span class="badge badge-info" title="CircleCI token configured">CircleCI token configured</span>
             </button>
             <button ng-disabled="attachingSource"  type="button" ng-click="detachSource(deviceForm.udid)" class="btn btn-default">
               <span title="Detach source from device" class="fa fa-chain-broken" ng-hide="attachingSource"></span>

--- a/src/app/views/source.html
+++ b/src/app/views/source.html
@@ -110,7 +110,8 @@
                     <i class="fa fa-code-fork font-weight-bold"></i> <span class="source-origin">{{source.branch}}</span>
                   </span>
                   <span ng-if="source.circle_key">
-                      <img src="https://circleci.com/gh/{{source.url | split:'git@github.com:':1 | split:'.git':0 }}.svg?style=svg&circle-token={{source.circle_key}}" />
+                      <span class="badge badge-info" title="CircleCI token configured">CircleCI token configured</span>
+                      <img ng-src="https://circleci.com/gh/{{source.url | split:'git@github.com:':1 | split:'.git':0 }}.svg?style=svg" alt="CircleCI build status" />
                   </span>
                   <span class="badge {{source.base_platform}}-platform-color platform-badge">{{$root.platforms[source.base_platform].name}}</span>
                 </div>

--- a/src/cypress/fixtures/thinx.json
+++ b/src/cypress/fixtures/thinx.json
@@ -1,6 +1,6 @@
 {
   "username": "dynamic",
-  "password": "dynamic",
+  "password": "",
   "email": "dynamic@example.com",
   "new": {
     "first_name": "cypress",

--- a/src/cypress/integration/login.spec.js
+++ b/src/cypress/integration/login.spec.js
@@ -7,11 +7,15 @@ describe('Login feature', function() {
     cy.visit('/');
   });
 
-  it('Should log in with static test account', function() {
+  it('Should log in with configured test account', function() {
+    const username = Cypress.env('THINX_TEST_USER') || data.username;
+    const password = Cypress.env('THINX_TEST_PASSWORD') || data.password;
+    expect(username, 'test username').to.be.a('string').and.not.be.empty;
+    expect(password, 'test password').to.be.a('string').and.not.be.empty;
     cy.get('.login-form .form-subtitle').should('contain', 'Please login', { matchCase: false });
-    cy.get('input[name="username"').type(data.username);
-      cy.get('input[name="password"').type(data.password);
-      cy.get('button').contains('login', { matchCase: false }).click();
+    cy.get('input[name="username"').type(username);
+    cy.get('input[name="password"').type(password, { log: false });
+    cy.get('button').contains('login', { matchCase: false }).click();
     // TODO check invalid name
     // TODO check invalid password
   });

--- a/src/default.conf
+++ b/src/default.conf
@@ -15,8 +15,10 @@ server {
     add_header "X-XSS-Protection" "1; mode=block";
     add_header "X-Content-Type-Options" "nosniff";
     add_header "X-Download-Options" "noopen";
-    add_header "X-Permitted-Cross-Domain-Policies" "all";
-    add_header "Content-Security-Policy" "default-src 'self' __WEB_HOSTNAME__ https: data: blob: 'unsafe-inline' 'unsafe-eval'; connect-src 'self' https: wss: wss://client.relay.crisp.chat; frame-ancestors 'self'; form-action 'self' __WEB_HOSTNAME__ https://github.com; object-src 'none'; base-uri 'self'" always;
+    add_header "X-Permitted-Cross-Domain-Policies" "none";
+    add_header "Referrer-Policy" "strict-origin-when-cross-origin" always;
+    add_header "Permissions-Policy" "camera=(), microphone=(), geolocation=()" always;
+    add_header "Content-Security-Policy" "default-src 'self' __WEB_HOSTNAME__ https: data: blob: 'unsafe-inline'; connect-src 'self' https: wss: wss://client.relay.crisp.chat; frame-ancestors 'self'; form-action 'self' __WEB_HOSTNAME__ https://github.com; object-src 'none'; base-uri 'self'" always;
     
     charset utf-8;
     source_charset utf-8;

--- a/vue/cypress/fixtures/thinx.json
+++ b/vue/cypress/fixtures/thinx.json
@@ -1,7 +1,7 @@
 {
   "viewport": [1600, 1200],
   "username": "test",
-  "password": "tset",
+  "password": "",
   "email": "dynamic@example.com",
   "new": {
     "first_name": "cypress",

--- a/vue/cypress/integration/login.spec.js
+++ b/vue/cypress/integration/login.spec.js
@@ -6,7 +6,7 @@ describe('Login feature', function() {
     cy.visit('http://localhost:3000/#/login');
   });
 
-  it.only('Should log in with static test account', function() {
+  it.only('Should log in with configured test account', function() {
     // TODO This is failing! Fix me!
     cy.login();
     // cy.get('.page-title').should('contain', 'Dashboard', { matchCase: false });

--- a/vue/cypress/support/commands.ts
+++ b/vue/cypress/support/commands.ts
@@ -28,6 +28,15 @@ import fixtures from '../fixtures/thinx.json';
 
 let LOCAL_STORAGE_MEMORY = {};
 
+function credentialFromEnv(value, envNames) {
+  if (value) return value;
+  for (const envName of envNames) {
+    const envValue = Cypress.env(envName);
+    if (envValue) return String(envValue);
+  }
+  return '';
+}
+
 Cypress.Commands.add('saveLocalStorage', () => {
   Object.keys(localStorage).forEach(key => {
     LOCAL_STORAGE_MEMORY[key] = localStorage[key];
@@ -41,10 +50,15 @@ Cypress.Commands.add('restoreLocalStorage', () => {
 });
 
 Cypress.Commands.add('login', (user, password) => {
+    const username = credentialFromEnv(user || fixtures.username, ['THINX_TEST_USER', 'LOGIN_USERNAME']);
+    const passwordValue = credentialFromEnv(password || fixtures.password, ['THINX_TEST_PASSWORD', 'LOGIN_PASSWORD']);
+    if (!username || !passwordValue) {
+      throw new Error('Set CYPRESS_THINX_TEST_USER and CYPRESS_THINX_TEST_PASSWORD, or pass credentials to cy.login().');
+    }
     cy.viewport(fixtures.viewport[0], fixtures.viewport[1]);
     cy.visit('/');
-    cy.get('#username').type(fixtures.username);
-    cy.get('#password').type(fixtures.password);
+    cy.get('#username').type(username);
+    cy.get('#password').type(passwordValue, { log: false });
     cy.get('button').contains('login', { matchCase: false }).click();
     cy.wait(2000);
 });
@@ -59,6 +73,9 @@ Cypress.Commands.add('login', (user, password) => {
 Cypress.Commands.add('loginAsAdmin', () => {
     const user = Cypress.env('ADMIN_USER');
     const password = Cypress.env('ADMIN_PASS');
+    if (!user || !password) {
+      throw new Error('Set CYPRESS_ADMIN_USER and CYPRESS_ADMIN_PASS before calling cy.loginAsAdmin().');
+    }
     cy.viewport(fixtures.viewport[0], fixtures.viewport[1]);
     cy.visit('/');
     cy.get('#username').type(user);
@@ -66,5 +83,3 @@ Cypress.Commands.add('loginAsAdmin', () => {
     cy.get('button').contains('login', { matchCase: false }).click();
     cy.wait(2000);
 });
-
-

--- a/vue/default.conf
+++ b/vue/default.conf
@@ -16,8 +16,10 @@ server {
     add_header "X-XSS-Protection" "1; mode=block";
     add_header "X-Content-Type-Options" "nosniff";
     add_header "X-Download-Options" "noopen";
-    add_header "X-Permitted-Cross-Domain-Policies" "all";
-    add_header "Content-Security-Policy" "default-src 'self' __NGINX_HOST__ https: data: blob: 'unsafe-inline' 'unsafe-eval'; connect-src 'self' https: wss: wss://client.relay.crisp.chat; frame-ancestors 'self'; form-action 'self' __NGINX_HOST__ https://github.com; object-src 'none'; base-uri 'self'" always;
+    add_header "X-Permitted-Cross-Domain-Policies" "none";
+    add_header "Referrer-Policy" "strict-origin-when-cross-origin" always;
+    add_header "Permissions-Policy" "camera=(), microphone=(), geolocation=()" always;
+    add_header "Content-Security-Policy" "default-src 'self' __NGINX_HOST__ https: data: blob: 'unsafe-inline'; connect-src 'self' https: wss: wss://client.relay.crisp.chat; frame-ancestors 'self'; form-action 'self' __NGINX_HOST__ https://github.com; object-src 'none'; base-uri 'self'" always;
     server_tokens off;
 
     # has no effect with HTTPS load-balancer unwrap

--- a/vue/src/App.vue
+++ b/vue/src/App.vue
@@ -3,23 +3,15 @@
 </template>
 
 <script>
-import { mapGetters, mapMutations, mapActions } from "vuex";
+import { mapActions } from "vuex";
+
+const PUBLIC_PATHS = ["/login", "/password-reset", "/error"];
 
 export default {
   name: "App",
-  computed: {
-    ...mapGetters({
-      isAuthenticated: "auth/isAuthenticated"
-    })
-  },
   methods: {
-    ...mapMutations({
-      setAccessToken: "auth/setAccessToken",
-      setRefreshToken: "auth/setRefreshToken",
-    }),
     ...mapActions({
-      isTokenValid: "auth/isTokenValid",
-      scheduleExpiry: "auth/scheduleExpiry",
+      hydrateSession: "auth/hydrateSession",
     }),
     async pushIfNeeded(location) {
       if (this.$route.fullPath === location) {
@@ -29,7 +21,7 @@ export default {
       try {
         await this.$router.push(location);
       } catch (error) {
-        if (error?.name !== "NavigationDuplicated") {
+        if (!error || error.name !== "NavigationDuplicated") {
           throw error;
         }
       }
@@ -37,35 +29,18 @@ export default {
   },
   async created() {
     const currentPath = this.$router.history.current.path;
-    const authenticated = this.isAuthenticated;// (window.localStorage.getItem("authenticated") === 'true');
+    const authenticated = await this.hydrateSession();
 
-    if (!authenticated) {
-      if (currentPath !== "/login") {
-        await this.pushIfNeeded("/login");
-      }
+    if (!authenticated && !PUBLIC_PATHS.includes(currentPath)) {
+      await this.pushIfNeeded("/login");
+      return;
     }
 
     if (authenticated) {
-      // init auth in vuex
-
-      let storedAccessToken = window.localStorage.getItem("accessToken");
-      let storedRefreshToken = window.localStorage.getItem("refreshToken");
-
-      if (await this.isTokenValid(storedAccessToken) && await this.isTokenValid(storedRefreshToken)) {
-        this.setAccessToken(storedAccessToken);
-        this.setRefreshToken(storedRefreshToken);
-        this.scheduleExpiry(storedAccessToken);
-      }
-
       // concat default paths
       if (currentPath === "/" || currentPath === "/app") {
         await this.pushIfNeeded("/app/dashboard");
       }
-
-      /*
-        TODO unwrap and check validity of this JWT token
-        retrieve accessToken from localstorage, if present
-      */
     }
   },
 };

--- a/vue/src/Routes.js
+++ b/vue/src/Routes.js
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import Router from 'vue-router';
 
 import store from '@/store';
+import { getPersistedAuthTokens } from '@/store/auth-storage';
 
 import Layout from '@/components/Layout/Layout';
 import Login from '@/pages/Login/Login';
@@ -136,16 +137,19 @@ const router = new Router({
 
 // AUTH-03 G5 — global auth guard so a torn-down session (clearSession ran but
 // the one-shot hash redirect was missed) can't navigate freely under /app/*.
-// Reads in-memory store first; falls back to localStorage for the cold-reload
-// path where App.vue.created hasn't yet rehydrated the store.
+// Reads in-memory store first; falls back to centralized session persistence
+// for the cold-reload path where App.vue.created hasn't yet rehydrated the store.
 const PUBLIC_PATHS = ['/login', '/password-reset', '/error'];
 const ADMIN_PATHS = ['/app/admin'];
 router.beforeEach((to, from, next) => {
   if (PUBLIC_PATHS.includes(to.path)) return next();
   if (!to.path.startsWith('/app')) return next();
+  const persistedTokens = typeof window !== 'undefined'
+    ? getPersistedAuthTokens()
+    : { accessToken: null };
   const authed =
     !!(store && store.state && store.state.auth && store.state.auth.accessToken) ||
-    !!(typeof window !== 'undefined' && window.localStorage.getItem('accessToken'));
+    !!persistedTokens.accessToken;
   if (!authed) return next('/login');
   if (ADMIN_PATHS.some(p => to.path.startsWith(p))) {
     const profile = (store && store.state && store.state.profile && store.state.profile.profile);

--- a/vue/src/components/ImpersonationBanner/ImpersonationBanner.vue
+++ b/vue/src/components/ImpersonationBanner/ImpersonationBanner.vue
@@ -8,6 +8,7 @@
 <script>
 import VueJwtDecode from "vue-jwt-decode";
 import { mapActions } from "vuex";
+import { getPersistedAuthTokens } from "@/store/auth-storage";
 
 export default {
   name: "ImpersonationBanner",
@@ -35,7 +36,7 @@ export default {
     ...mapActions({ clearSession: "auth/clearSession" }),
     decode() {
       try {
-        const token = window.localStorage.getItem('accessToken');
+        const token = this.$store.getters["auth/getAccessToken"] || getPersistedAuthTokens().accessToken;
         if (!token) { this.impersonatorOwner = null; return; }
         const decoded = VueJwtDecode.decode(token);
         if (decoded && decoded.impersonator_owner) {

--- a/vue/src/components/Widget/Widget.vue
+++ b/vue/src/components/Widget/Widget.vue
@@ -7,8 +7,8 @@
     loading: fetchingData
   }" ref="widget">
     <h5 v-if="title && typeof title === 'string' && !customHeader" class="title">{{title}}</h5>
-    <header v-if="title && customHeader" class="title" v-html="title"></header>
-    <div v-if="!customControls && mainControls"
+    <header v-if="title && customHeader" class="title">{{title}}</header>
+    <div v-if="mainControls"
       class="widgetControls widget-controls">
       <a v-if="settings" href="#"><i class="la la-cog" /></a>
       <a v-if="settingsInverse" href="#" class="bg-default mx-2">
@@ -75,7 +75,6 @@
         </b-tooltip>
       </a>
     </div>
-    <div v-if="customControls" v-html="customControls" ref="customControlsRef" class="widgetControls widget-controls"></div>
     <div :class="`widgetBody widget-body ${bodyClass}`" ref="widgetBodyRef"
           :style="{display: state === 'collapse' ? 'none' : ''}"
     >
@@ -107,7 +106,6 @@ export default {
     refresh: { type: [Boolean, String], default: false },
     className: { default: '' },
     title: { default: '' },
-    customControls: { default: null },
     bodyClass: { default: '' },
     options: { default: () => ({}) },
     fetchingData: {type: Boolean, default: false},
@@ -131,20 +129,6 @@ export default {
       if (typeof this.autoload === 'number') {
         setInterval(() => {this.loadWidgster()}, this.autoload);
       }
-    }
-    if (this.customControls) {
-      let close = this.$refs.customControlsRef.querySelector('[control=close]');
-      close && close.addEventListener('click', this.closeWidget);
-      let collapse = this.$refs.customControlsRef.querySelector('[control=collapse]');
-      collapse && collapse.addEventListener('click', this.changeState.bind(this, null, 'collapse'));
-      let expand = this.$refs.customControlsRef.querySelector('[control=expand]');
-      expand && expand.addEventListener('click', this.changeState.bind(this, null, 'default'));
-      let fullscreen = this.$refs.customControlsRef.querySelector('[control=fullscreen]');
-      fullscreen && fullscreen.addEventListener('click', this.changeState.bind(this, null, 'fullscreen'));
-      let restore = this.$refs.customControlsRef.querySelector('[control=restore]');
-      restore && restore.addEventListener('click', this.changeState.bind(this, null, 'default'));
-      let load = this.$refs.customControlsRef.querySelector('[control=load]');
-      load && load.addEventListener('click', this.loadWidgster);
     }
   },
   methods: {

--- a/vue/src/core/api.js
+++ b/vue/src/core/api.js
@@ -1,3 +1,5 @@
+import { clearPersistedAuthTokens } from "@/store/auth-storage";
+
 export default class Api {
 
   constructor(hostname) {
@@ -17,19 +19,17 @@ export default class Api {
     // (e.g. laptop slept past the auth/scheduleExpiry setTimeout firing time), tear
     // down the session synchronously before issuing the request. The request itself
     // is still issued — it will 401, but the page is already navigating to /login.
-    // Reads this.refreshToken because of the token-name swap at setAccessToken (line 50):
-    // setAccessToken stores its argument as this.refreshToken, so this.refreshToken IS
-    // the access JWT. Uses platform atob + JSON.parse to avoid loading the JWT decode
-    // library into the API client (kept dependency-free).
-    if (this.refreshToken) {
+    // Uses platform atob + JSON.parse to avoid loading the JWT decode library
+    // into the API client (kept dependency-free).
+    if (this.accessToken) {
       try {
-        const parts = this.refreshToken.split('.');
+        const parts = this.accessToken.split('.');
         if (parts.length === 3) {
           const payload = JSON.parse(atob(parts[1]));
           if (payload && typeof payload.exp === 'number' && payload.exp * 1000 < Date.now()) {
-            window.localStorage.removeItem('accessToken');
-            window.localStorage.removeItem('refreshToken');
-            window.localStorage.removeItem('authenticated');
+            clearPersistedAuthTokens();
+            this.accessToken = null;
+            this.refreshToken = null;
             if (typeof window !== 'undefined') window.location.hash = '#/login';
             // fall through — the request will 401 and the page is already navigating
           }
@@ -50,11 +50,13 @@ export default class Api {
   }
 
   composeHeaders() {
-    return {
+    const headers = {
       "Content-Type": "application/json",
-      'Authorization': 'Bearer ' + this.refreshToken,
-      'Access-Control-Allow-Origin': 'http://localhost:3080 ' + this.baseApiUrl,
+    };
+    if (this.accessToken) {
+      headers.Authorization = 'Bearer ' + this.accessToken;
     }
+    return headers;
   }
 
   composePath(path) {
@@ -73,11 +75,11 @@ export default class Api {
   }
 
   setAccessToken(token) {
-    this.refreshToken = token;
+    this.accessToken = token || null;
   }
 
   setRefreshToken(token) {
-    this.accessToken = token;
+    this.refreshToken = token || null;
   }
 
   async request(method, path, body) {

--- a/vue/src/pages/AdminUsers/AdminUsers.vue
+++ b/vue/src/pages/AdminUsers/AdminUsers.vue
@@ -50,7 +50,7 @@
 </template>
 
 <script>
-import { mapActions, mapGetters, mapMutations } from "vuex";
+import { mapActions, mapGetters } from "vuex";
 
 export default {
   name: "AdminUsers",
@@ -86,9 +86,8 @@ export default {
       fetchUsers: 'admin/fetchUsers',
       revokeSession: 'admin/revokeSession',
       impersonate: 'admin/impersonate',
-      scheduleExpiry: 'auth/scheduleExpiry',
+      persistSession: 'auth/persistSession',
     }),
-    ...mapMutations({ setAccessToken: 'auth/setAccessToken' }),
     formatDate(ts) {
       if (!ts) return '—';
       try { return new Date(ts).toLocaleString(); } catch (_e) { return String(ts); }
@@ -126,10 +125,7 @@ export default {
         this.error = 'Impersonation token missing from server response.';
         return;
       }
-      window.localStorage.setItem('accessToken', access_token);
-      window.localStorage.removeItem('refreshToken');
-      this.setAccessToken(access_token);
-      this.scheduleExpiry(access_token);
+      await this.persistSession({ accessToken: access_token, refreshToken: null });
       this.$router.push('/app/dashboard');
     },
   },

--- a/vue/src/pages/Login/Login.vue
+++ b/vue/src/pages/Login/Login.vue
@@ -3,8 +3,7 @@
     <b-container>
       <Widget
         class="widget-auth mx-auto"
-        title="<h3 class='mt-0'>THiNX Login</h3>"
-        customHeader
+        title="THiNX Login"
       >
         <p class="widget-auth-info">Use your username to sign in.</p>
         <form class="mt" @submit.prevent="login">
@@ -98,7 +97,7 @@
 
 <script>
 import Widget from "@/components/Widget/Widget";
-import { mapMutations, mapGetters, mapActions } from "vuex";
+import { mapGetters, mapActions } from "vuex";
 import hostnameMixin from "@/mixins/hostnames";
 
 export default {
@@ -112,15 +111,11 @@ export default {
     };
   },
   methods: {
-    ...mapMutations({
-      setAccessToken: "auth/setAccessToken",
-      setRefreshToken: "auth/setRefreshToken",
-      setUser: "auth/setUser",
-    }),
     ...mapActions({
+      persistSession: "auth/persistSession",
+      hydrateSession: "auth/hydrateSession",
       fetchProfile: "profile/fetchProfile",
       isTokenValid: "auth/isTokenValid",
-      scheduleExpiry: "auth/scheduleExpiry",
     }),
     ...mapGetters({
       isAuthenticated: "auth/isAuthenticated",
@@ -134,7 +129,7 @@ export default {
       try {
         await this.$router.push(location);
       } catch (error) {
-        if (error?.name !== "NavigationDuplicated") {
+        if (!error || error.name !== "NavigationDuplicated") {
           throw error;
         }
       }
@@ -159,7 +154,6 @@ export default {
           credentials: "include",
           headers: {
             "Content-Type": "application/json",
-            "Access-Control-Allow-Origin": "http://localhost:3080 " + this.$hostnames.API,
           },
           body: JSON.stringify({
             username: usernameValue,
@@ -197,34 +191,20 @@ export default {
         (await this.isTokenValid(access_token)) &&
         (await this.isTokenValid(refresh_token))
       ) {
-        this.setAccessToken(access_token);
-        this.setRefreshToken(refresh_token);
-        this.scheduleExpiry(access_token);
+        await this.persistSession({ accessToken: access_token, refreshToken: refresh_token });
       }
 
       if (this.isAuthenticated()) {
-        window.localStorage.setItem("accessToken", access_token);
-        window.localStorage.setItem("refreshToken", refresh_token);
-        window.localStorage.setItem("authenticated", true);
-
         await this.fetchProfile();
-        this.setUser(this.getProfile());
+        this.$store.commit("auth/setUser", this.getProfile());
         await this.pushIfNeeded("/app/dashboard");
       } else {
         this.errorMessage = "Token expired";
       }
     },
   },
-  created() {
-    // TTODO validate
-    const authenticated = window.localStorage.getItem("authenticated") === "true";
-    const accessToken = window.localStorage.getItem("accessToken");
-    const refreshToken = window.localStorage.getItem("refreshToken");
-
-    if (authenticated && accessToken) {
-      this.setAccessToken(accessToken);
-      this.setRefreshToken(refreshToken);
-      this.scheduleExpiry(accessToken);
+  async created() {
+    if (await this.hydrateSession()) {
       void this.pushIfNeeded("/app/dashboard");
     }
   },

--- a/vue/src/pages/PasswordReset/PasswordReset.vue
+++ b/vue/src/pages/PasswordReset/PasswordReset.vue
@@ -3,8 +3,7 @@
     <b-container>
       <Widget
         class="widget-auth mx-auto"
-        title="<h3 class='mt-0'>Password Reset</h3>"
-        customHeader
+        title="Password Reset"
       >
         <!-- Initiate form -->
         <form v-if="!hasResetToken" @submit.prevent="submitInitiate">

--- a/vue/src/pages/Profile/Profile.vue
+++ b/vue/src/pages/Profile/Profile.vue
@@ -302,9 +302,9 @@ export default {
       const result = await this.deleteAccount();
       if (result.success) {
         // G7 fix: account is gone server-side, so tear down the local session
-        // (3 localStorage keys + 3 Vuex slots + cancel expiry timer) BEFORE
-        // routing. Without this, localStorage.authenticated lingers and the
-        // router.beforeEach guard treats the orphaned page as still logged in
+        // (persisted auth tokens + Vuex slots + cancel expiry timer) BEFORE
+        // routing. Without this, the router.beforeEach guard treats the
+        // orphaned page as still logged in
         // (same chokepoint as Header.vue#logout — Phase 8 Wave 2, 0295a69).
         await this.$store.dispatch('auth/clearSession');
         this.$router.push('/login');

--- a/vue/src/pages/Visits/Visits.vue
+++ b/vue/src/pages/Visits/Visits.vue
@@ -242,15 +242,19 @@ export default {
       if (!item.build_id) return;
       const profile = this.getProfile() || {};
       const owner = profile.owner || '';
+      const headers = {
+        'Content-Type': 'application/json',
+      };
+      const accessToken = this.$store.$api.accessToken;
+      if (accessToken) {
+        headers.Authorization = 'Bearer ' + accessToken;
+      }
       let response;
       try {
         response = await fetch(this.$hostnames.API + '/build/artifacts', {
           method: 'POST',
           credentials: 'include',
-          headers: {
-            'Content-Type': 'application/json',
-            'Authorization': 'Bearer ' + this.$store.$api.refreshToken,
-          },
+          headers,
           body: JSON.stringify({ owner, udid: item.udid, build_id: item.build_id }),
         });
       } catch (networkError) {

--- a/vue/src/store/auth-storage.js
+++ b/vue/src/store/auth-storage.js
@@ -1,0 +1,92 @@
+const ACCESS_TOKEN_KEY = 'accessToken';
+const REFRESH_TOKEN_KEY = 'refreshToken';
+const AUTHENTICATED_KEY = 'authenticated';
+
+function getBrowserStorage(name) {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window[name] || null;
+  } catch (_error) {
+    return null;
+  }
+}
+
+function getItem(storage, key) {
+  try {
+    return storage ? storage.getItem(key) : null;
+  } catch (_error) {
+    return null;
+  }
+}
+
+function setItem(storage, key, value) {
+  if (!storage) return;
+  try {
+    if (value) {
+      storage.setItem(key, value);
+    } else {
+      storage.removeItem(key);
+    }
+  } catch (_error) {
+    // Storage may be unavailable in hardened browser modes; keep auth in memory.
+  }
+}
+
+function removeItem(storage, key) {
+  if (!storage) return;
+  try {
+    storage.removeItem(key);
+  } catch (_error) {
+    // Ignore storage cleanup failures.
+  }
+}
+
+export function clearLegacyAuthStorage() {
+  const storage = getBrowserStorage('localStorage');
+  removeItem(storage, ACCESS_TOKEN_KEY);
+  removeItem(storage, REFRESH_TOKEN_KEY);
+  removeItem(storage, AUTHENTICATED_KEY);
+}
+
+export function getPersistedAuthTokens() {
+  const session = getBrowserStorage('sessionStorage');
+  const accessToken = getItem(session, ACCESS_TOKEN_KEY);
+  const refreshToken = getItem(session, REFRESH_TOKEN_KEY);
+
+  if (accessToken || refreshToken) {
+    clearLegacyAuthStorage();
+    return { accessToken, refreshToken };
+  }
+
+  const legacy = getBrowserStorage('localStorage');
+  const legacyAccessToken = getItem(legacy, ACCESS_TOKEN_KEY);
+  const legacyRefreshToken = getItem(legacy, REFRESH_TOKEN_KEY);
+
+  if (legacyAccessToken || legacyRefreshToken) {
+    persistAuthTokens({
+      accessToken: legacyAccessToken,
+      refreshToken: legacyRefreshToken,
+    });
+    return {
+      accessToken: legacyAccessToken,
+      refreshToken: legacyRefreshToken,
+    };
+  }
+
+  clearLegacyAuthStorage();
+  return { accessToken: null, refreshToken: null };
+}
+
+export function persistAuthTokens({ accessToken, refreshToken }) {
+  const session = getBrowserStorage('sessionStorage');
+  setItem(session, ACCESS_TOKEN_KEY, accessToken);
+  setItem(session, REFRESH_TOKEN_KEY, refreshToken);
+  clearLegacyAuthStorage();
+}
+
+export function clearPersistedAuthTokens() {
+  const session = getBrowserStorage('sessionStorage');
+  removeItem(session, ACCESS_TOKEN_KEY);
+  removeItem(session, REFRESH_TOKEN_KEY);
+  clearLegacyAuthStorage();
+}

--- a/vue/src/store/auth.js
+++ b/vue/src/store/auth.js
@@ -1,9 +1,25 @@
 import VueJwtDecode from "vue-jwt-decode";
+import {
+  clearPersistedAuthTokens,
+  getPersistedAuthTokens,
+  persistAuthTokens,
+} from "./auth-storage";
 
 // Module-private setTimeout id for the session-expiry watcher (AUTH-03).
 // Kept outside Vuex state so we can clear/replace it across action dispatches
 // without triggering reactivity overhead or committing a mutation.
 let expiryTimerId = null;
+
+function isJwtValid(token) {
+  if (!token) return false;
+  try {
+    const nowUnixtime = Math.floor(Date.now() / 1000);
+    const decoded = VueJwtDecode.decode(token);
+    return decoded.exp > nowUnixtime;
+  } catch (error) {
+    return false;
+  }
+}
 
 export default {
     namespaced: true,
@@ -18,41 +34,55 @@ export default {
         },
         setAccessToken(state, token) {
           // TODO use validation
-          state.accessToken = token;
+          state.accessToken = token || null;
           this.$api.setAccessToken(state.accessToken);
         },
         setRefreshToken(state, token) {
           // TODO use validation
-          state.refreshToken = token;
+          state.refreshToken = token || null;
           this.$api.setRefreshToken(state.refreshToken);
         },
       },
     actions: {
-      removeAccessToken(state) {
-        window.localStorage.removeItem('accessToken');
-        state.accessToken = undefined;
+      removeAccessToken({ commit, state }) {
+        persistAuthTokens({ accessToken: null, refreshToken: state.refreshToken });
+        commit('setAccessToken', null);
       },
-      removeRefreshToken(state) {
-        window.localStorage.removeItem('refreshToken');
-        state.refreshToken = undefined;
+      removeRefreshToken({ commit, state }) {
+        persistAuthTokens({ accessToken: state.accessToken, refreshToken: null });
+        commit('setRefreshToken', null);
       },
       isTokenValid(_, token) {
-        try {
-            const nowUnixtime = Math.floor(Date.now() / 1000);
-            let decoded = VueJwtDecode.decode(token);
-            return decoded.exp <= nowUnixtime ? false : true;
-        } catch (error) {
-            return false
+        return isJwtValid(token);
+      },
+      persistSession({ commit, dispatch }, { accessToken, refreshToken = null }) {
+        if (!accessToken) {
+          dispatch('clearSession');
+          return false;
         }
+        persistAuthTokens({ accessToken, refreshToken });
+        commit('setAccessToken', accessToken);
+        commit('setRefreshToken', refreshToken);
+        dispatch('scheduleExpiry', accessToken);
+        return true;
+      },
+      hydrateSession({ commit, dispatch }) {
+        const { accessToken, refreshToken } = getPersistedAuthTokens();
+        if (!accessToken || !isJwtValid(accessToken) || (refreshToken && !isJwtValid(refreshToken))) {
+          dispatch('clearSession');
+          return false;
+        }
+        commit('setAccessToken', accessToken);
+        commit('setRefreshToken', refreshToken);
+        dispatch('scheduleExpiry', accessToken);
+        return true;
       },
       clearSession({ commit }) {
         if (expiryTimerId) {
           clearTimeout(expiryTimerId);
           expiryTimerId = null;
         }
-        window.localStorage.removeItem('accessToken');
-        window.localStorage.removeItem('refreshToken');
-        window.localStorage.removeItem('authenticated');
+        clearPersistedAuthTokens();
         commit('setAccessToken', null);
         commit('setRefreshToken', null);
         commit('setUser', null);


### PR DESCRIPTION
## Summary
- Move Vue access/refresh token persistence behind a centralized sessionStorage helper, including legacy localStorage cleanup and no authenticated sentinel writes.
- Fix API client token naming so Authorization uses the access token only when present, and remove bogus Access-Control-Allow-Origin request headers.
- Remove Widget raw HTML header/customControls rendering and convert login/reset titles to plain text.
- Remove CircleCI token query parameters from legacy badge URLs while showing token-configured status.
- Tighten Vue and legacy Nginx headers: X-Permitted-Cross-Domain-Policies none, Referrer-Policy, Permissions-Policy, and CSP without unsafe-eval.
- Prefer Cypress env credentials and remove committed fixture passwords.

## Validation
- PASS: cd vue && yarn build
- PASS: cd vue && ./node_modules/.bin/vue-cli-service lint src/App.vue src/Routes.js src/components/ImpersonationBanner/ImpersonationBanner.vue src/components/Widget/Widget.vue src/core/api.js src/pages/AdminUsers/AdminUsers.vue src/pages/Login/Login.vue src/pages/PasswordReset/PasswordReset.vue src/pages/Profile/Profile.vue src/pages/Visits/Visits.vue src/store/auth.js src/store/auth-storage.js cypress/support/commands.ts cypress/integration/login.spec.js
- PASS: targeted rg checks for localStorage token writes, Access-Control-Allow-Origin request headers, Widget v-html, circle-token URL interpolation, unsafe-eval, and permissive X-Permitted-Cross-Domain-Policies.
- PASS: cd src && npm run build
- NOTE: cd vue && yarn lint still fails on pre-existing baseline issues in src/pages/Transformers/TransformerEditor.vue, src/store/devices.js, and vue.config.js.
- NOTE: cd src && npm run lint is blocked by the existing ESLint CLI/script mismatch: --ignore-path is rejected.
- SKIPPED: credentialed Cypress auth/login specs because CYPRESS_THINX_TEST_USER/CYPRESS_THINX_TEST_PASSWORD and admin creds are not configured in this shell.

## Follow-ups
- Full HttpOnly cookie auth migration remains backend/API-contract work.
- Backend CORS policy tightening remains out of scope here.
- Broad dependency/security upgrades remain separate work.